### PR TITLE
ci: add CLI auto-publish workflow and PR template

### DIFF
--- a/.claude/skills/pr-description/SKILL.md
+++ b/.claude/skills/pr-description/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: pr-description
+description: Generate a PR description following the project's pull_request_template.md. Use when the user says "create PR", "open PR", "PR description", "generate PR body", "建立 PR", or wants to create a pull request with a structured description.
+---
+
+# PR Description
+
+Generate a PR description that follows the project template at `.github/pull_request_template.md`.
+
+## Workflow
+
+### 1. Collect change information
+
+Run these commands in parallel:
+
+```bash
+git log --oneline main..HEAD
+git diff main...HEAD --stat
+git diff main...HEAD
+```
+
+### 2. Read the PR template
+
+Read `.github/pull_request_template.md` to get the current template structure.
+
+### 3. Generate the PR description
+
+Fill in each section of the template:
+
+- **Summary**: Analyze all commits and diffs, write 1-3 bullet points describing what the PR does. Focus on the "why", not the "what".
+- **Type of Change**: Check the single most appropriate type based on the changes. If multiple types apply, check the primary one.
+- **Related Issues**: Reference any issue numbers found in commit messages or branch names. Leave empty if none.
+- **Test Plan**: Check the boxes that apply based on what was actually tested or is relevant.
+- **Screenshots**: Remove this section entirely unless the PR includes UI changes.
+
+### 4. Create the PR
+
+Use `gh pr create` with the generated description:
+
+```bash
+gh pr create --title "<conventional commit style title>" --body "$(cat <<'EOF'
+<generated PR body>
+EOF
+)"
+```
+
+## Rules
+
+- Always read the template file first — do not hardcode the template structure
+- Keep the summary concise and meaningful
+- Use imperative mood in the PR title (e.g., "add", "fix", "update")
+- PR title should follow Conventional Commits format and stay under 72 characters
+- Analyze ALL commits in the branch, not just the latest one
+- Push the branch to remote before creating the PR if not already pushed

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,29 @@
+## Summary
+
+<!-- What does this PR do? Keep it to 1-3 bullet points. -->
+
+-
+
+## Type of Change
+
+- [ ] feat: new feature
+- [ ] fix: bug fix
+- [ ] refactor: code restructuring (no behavior change)
+- [ ] chore: maintenance, CI, deps
+- [ ] docs: documentation only
+
+## Related Issues
+
+<!-- Link related issues: closes #123, fixes #456 -->
+
+## Test Plan
+
+<!-- How was this tested? -->
+
+- [ ] Tested locally
+- [ ] Lint passes (`pnpm lint`)
+- [ ] Typecheck passes (`pnpm typecheck`)
+
+## Screenshots
+
+<!-- If UI changes, add before/after screenshots. Remove this section if not applicable. -->

--- a/.github/workflows/cli-publish.yml
+++ b/.github/workflows/cli-publish.yml
@@ -1,0 +1,37 @@
+name: cli-publish
+
+on:
+  push:
+    tags:
+      - 'cli@*'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Install node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: pnpm
+          registry-url: https://registry.npmjs.org
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build CLI
+        run: pnpm --filter @curl-ticket/cli build
+
+      - name: Publish to npm (provenance via OIDC Trusted Publishing)
+        run: pnpm --filter @curl-ticket/cli publish --no-git-checks --access public --provenance

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,31 @@ node scripts/verify-schema.mjs    # Print current database schema from informati
 node scripts/reset-db.mjs         # Drop all app tables and migration history (destructive!)
 ```
 
+## Branch Strategy
+
+**Feature Branch Workflow** — `main` is always deployable. All development happens on short-lived feature branches.
+
+```
+main (always deployable)
+  ├── feat/xxx          ← new features
+  ├── fix/xxx           ← bug fixes
+  └── chore/xxx         ← maintenance, CI, docs
+```
+
+**Rules:**
+- Feature branches merge back to `main` via PR
+- CLI releases: tag `cli@x.x.x` on `main` triggers CI auto `npm publish`
+
+### CLI Version Release Flow
+```bash
+# 1. Merge feature branch to main
+# 2. Bump version and tag on main
+cd packages/cli
+npm version patch    # or minor / major
+git push && git push --tags
+# 3. CI detects cli@* tag → auto build + npm publish
+```
+
 ## Architecture
 
 ### Tech Stack


### PR DESCRIPTION
## Summary

- Add GitHub Actions workflow to auto-publish `@curl-ticket/cli` to npm when a `cli@*` tag is pushed, using OIDC Trusted Publishing (no secrets needed)
- Add PR template and `pr-description` skill to standardize PR descriptions
- Document branch strategy and CLI release flow in CLAUDE.md

## Type of Change

- [x] chore: maintenance, CI, deps

## Related Issues

## Test Plan

- [ ] Tested locally
- [x] Lint passes (`pnpm lint`)
- [x] Typecheck passes (`pnpm typecheck`)