### PR TITLE
feat(cli): agent-first optimizations v0.3.0

### DIFF
--- a/.agents/skills/improve-codebase-architecture/REFERENCE.md
+++ b/.agents/skills/improve-codebase-architecture/REFERENCE.md
@@ -1,0 +1,78 @@
+# Reference
+
+## Dependency Categories
+
+When assessing a candidate for deepening, classify its dependencies:
+
+### 1. In-process
+
+Pure computation, in-memory state, no I/O. Always deepenable — just merge the modules and test directly.
+
+### 2. Local-substitutable
+
+Dependencies that have local test stand-ins (e.g., PGLite for Postgres, in-memory filesystem). Deepenable if the test substitute exists. The deepened module is tested with the local stand-in running in the test suite.
+
+### 3. Remote but owned (Ports & Adapters)
+
+Your own services across a network boundary (microservices, internal APIs). Define a port (interface) at the module boundary. The deep module owns the logic; the transport is injected. Tests use an in-memory adapter. Production uses the real HTTP/gRPC/queue adapter.
+
+Recommendation shape: "Define a shared interface (port), implement an HTTP adapter for production and an in-memory adapter for testing, so the logic can be tested as one deep module even though it's deployed across a network boundary."
+
+### 4. True external (Mock)
+
+Third-party services (Stripe, Twilio, etc.) you don't control. Mock at the boundary. The deepened module takes the external dependency as an injected port, and tests provide a mock implementation.
+
+## Testing Strategy
+
+The core principle: **replace, don't layer.**
+
+- Old unit tests on shallow modules are waste once boundary tests exist — delete them
+- Write new tests at the deepened module's interface boundary
+- Tests assert on observable outcomes through the public interface, not internal state
+- Tests should survive internal refactors — they describe behavior, not implementation
+
+## Issue Template
+
+<issue-template>
+
+## Problem
+
+Describe the architectural friction:
+
+- Which modules are shallow and tightly coupled
+- What integration risk exists in the seams between them
+- Why this makes the codebase harder to navigate and maintain
+
+## Proposed Interface
+
+The chosen interface design:
+
+- Interface signature (types, methods, params)
+- Usage example showing how callers use it
+- What complexity it hides internally
+
+## Dependency Strategy
+
+Which category applies and how dependencies are handled:
+
+- **In-process**: merged directly
+- **Local-substitutable**: tested with [specific stand-in]
+- **Ports & adapters**: port definition, production adapter, test adapter
+- **Mock**: mock boundary for external services
+
+## Testing Strategy
+
+- **New boundary tests to write**: describe the behaviors to verify at the interface
+- **Old tests to delete**: list the shallow module tests that become redundant
+- **Test environment needs**: any local stand-ins or adapters required
+
+## Implementation Recommendations
+
+Durable architectural guidance that is NOT coupled to current file paths:
+
+- What the module should own (responsibilities)
+- What it should hide (implementation details)
+- What it should expose (the interface contract)
+- How callers should migrate to the new interface
+
+</issue-template>

--- a/.agents/skills/improve-codebase-architecture/SKILL.md
+++ b/.agents/skills/improve-codebase-architecture/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: improve-codebase-architecture
+description: Explore a codebase to find opportunities for architectural improvement, focusing on making the codebase more testable by deepening shallow modules. Use when user wants to improve architecture, find refactoring opportunities, consolidate tightly-coupled modules, or make a codebase more AI-navigable.
+---
+
+# Improve Codebase Architecture
+
+Explore a codebase like an AI would, surface architectural friction, discover opportunities for improving testability, and propose module-deepening refactors as GitHub issue RFCs.
+
+A **deep module** (John Ousterhout, "A Philosophy of Software Design") has a small interface hiding a large implementation. Deep modules are more testable, more AI-navigable, and let you test at the boundary instead of inside.
+
+## Process
+
+### 1. Explore the codebase
+
+Use the Agent tool with subagent_type=Explore to navigate the codebase naturally. Do NOT follow rigid heuristics — explore organically and note where you experience friction:
+
+- Where does understanding one concept require bouncing between many small files?
+- Where are modules so shallow that the interface is nearly as complex as the implementation?
+- Where have pure functions been extracted just for testability, but the real bugs hide in how they're called?
+- Where do tightly-coupled modules create integration risk in the seams between them?
+- Which parts of the codebase are untested, or hard to test?
+
+The friction you encounter IS the signal.
+
+### 2. Present candidates
+
+Present a numbered list of deepening opportunities. For each candidate, show:
+
+- **Cluster**: Which modules/concepts are involved
+- **Why they're coupled**: Shared types, call patterns, co-ownership of a concept
+- **Dependency category**: See [REFERENCE.md](REFERENCE.md) for the four categories
+- **Test impact**: What existing tests would be replaced by boundary tests
+
+Do NOT propose interfaces yet. Ask the user: "Which of these would you like to explore?"
+
+### 3. User picks a candidate
+
+### 4. Frame the problem space
+
+Before spawning sub-agents, write a user-facing explanation of the problem space for the chosen candidate:
+
+- The constraints any new interface would need to satisfy
+- The dependencies it would need to rely on
+- A rough illustrative code sketch to make the constraints concrete — this is not a proposal, just a way to ground the constraints
+
+Show this to the user, then immediately proceed to Step 5. The user reads and thinks about the problem while the sub-agents work in parallel.
+
+### 5. Design multiple interfaces
+
+Spawn 3+ sub-agents in parallel using the Agent tool. Each must produce a **radically different** interface for the deepened module.
+
+Prompt each sub-agent with a separate technical brief (file paths, coupling details, dependency category, what's being hidden). This brief is independent of the user-facing explanation in Step 4. Give each agent a different design constraint:
+
+- Agent 1: "Minimize the interface — aim for 1-3 entry points max"
+- Agent 2: "Maximize flexibility — support many use cases and extension"
+- Agent 3: "Optimize for the most common caller — make the default case trivial"
+- Agent 4 (if applicable): "Design around the ports & adapters pattern for cross-boundary dependencies"
+
+Each sub-agent outputs:
+
+1. Interface signature (types, methods, params)
+2. Usage example showing how callers use it
+3. What complexity it hides internally
+4. Dependency strategy (how deps are handled — see [REFERENCE.md](REFERENCE.md))
+5. Trade-offs
+
+Present designs sequentially, then compare them in prose.
+
+After comparing, give your own recommendation: which design you think is strongest and why. If elements from different designs would combine well, propose a hybrid. Be opinionated — the user wants a strong read, not just a menu.
+
+### 6. User picks an interface (or accepts recommendation)
+
+### 7. Create GitHub issue
+
+Create a refactor RFC as a GitHub issue using `gh issue create`. Use the template in [REFERENCE.md](REFERENCE.md). Do NOT ask the user to review before creating — just create it and share the URL.

--- a/.claude/skills/improve-codebase-architecture
+++ b/.claude/skills/improve-codebase-architecture
@@ -1,0 +1,1 @@
+../../.agents/skills/improve-codebase-architecture

--- a/.codex/skills/improve-codebase-architecture
+++ b/.codex/skills/improve-codebase-architecture
@@ -1,0 +1,1 @@
+../../.agents/skills/improve-codebase-architecture

--- a/docs/prd/cli-integration/README.md
+++ b/docs/prd/cli-integration/README.md
@@ -114,27 +114,27 @@ Phase A 和 B 可平行開發（前端頁面 + 後端 API 可分工）。Phase C
 - `CLI-069`：`--json` 模式下錯誤輸出結構化 JSON。
 - SKILL.md 已更新，指示 Agent 一律使用 `--json` flag。
 
-### E2. Input Hardening（防禦 Agent Hallucination）
+### E2. Input Hardening（防禦 Agent Hallucination）（已完成 ✓）
 
-- `CLI-070`：`--type` 過濾參數需驗證合法值（`api_bug` / `task`），非法值時列出可用選項並以 exit code 結束。
+- `CLI-070`：`--type` 過濾參數需驗證合法值（`api_bug` / `task`），非法值時列出可用選項並以 exit code 4 結束。
 - `CLI-071`：`projectId` 參數需驗證 UUID 格式（`/^[0-9a-f-]{36}$/i`），防止 hallucinated ID 直接拼入 URL。
 - `CLI-072`：寫入操作（`update-status`）支援 `--dry-run` flag，輸出預期變更但不實際執行，讓 Agent 可先預覽再確認。
 
-### E3. Context Window Discipline（Field Mask）
+### E3. Context Window Discipline（Field Mask）（已完成 ✓）
 
-- `CLI-073`：`issue` 指令支援 `--fields` 選項（例如 `--fields status,endpoint,error`），在 `--json` 模式下僅回傳指定欄位。
-- `CLI-074`：預設 field set 為所有欄位；當指定 `--fields` 時，省略 `rawCurl`、`requestHeaders`、`responseBody` 等大型欄位，減少 token 開銷。
+- `CLI-073`：`issue` 指令支援 `--fields` 選項（例如 `--fields status,url,method`），在 `--json` 模式下僅回傳指定欄位（`id` 永遠包含）。
+- `CLI-074`：預設 field set 為所有欄位；當指定 `--fields` 時，省略未列出的欄位，減少 token 開銷。
 - `CLI-075`：`--fields` 僅在 `--json` 模式下生效；human-readable 模式忽略此選項。
 
-### E4. Schema Introspection（自我描述能力）
+### E4. Schema Introspection（自我描述能力）（已完成 ✓）
 
-- `CLI-076`：新增 `curl-ticket schema` 指令，輸出所有指令的 JSON Schema（指令名稱、參數、型別、enum 值、描述）。
-- `CLI-077`：`schema` 輸出包含 status enum（`Open`, `In Progress`, `Done`, `Close`）、type enum（`api_bug`, `task`）、所有可用 fields 名稱。
+- `CLI-076`：新增 `curl-ticket schema` 指令，輸出所有指令的 JSON Schema（指令名稱、參數、型別、enum 值、描述）。不需認證。
+- `CLI-077`：`schema` 輸出包含 status enum（`Open`, `In Progress`, `Done`, `Close`）、type enum（`api_bug`, `task`）、所有可用 fields 名稱、exit code 定義。
 - `CLI-078`：Agent 可透過 `curl-ticket schema` 在首次呼叫時了解所有可用操作與合法值，減少 hallucination。
 
-### E5. Exit Code 語義化
+### E5. Exit Code 語義化（已完成 ✓）
 
-- `CLI-079`：區分 exit code：`0`=成功, `1`=一般錯誤, `2`=認證錯誤, `3`=資源不存在, `4`=輸入驗證錯誤。
+- `CLI-079`：區分 exit code：`0`=成功, `1`=一般錯誤, `2`=認證錯誤, `3`=資源不存在, `4`=輸入驗證錯誤。`--json` 模式下錯誤 JSON 包含 `exitCode` 欄位。
 - `CLI-080`：Agent 可透過 exit code 直接判斷錯誤類型，不需 parse stderr 文字。
 
 ### E6. Batch 操作
@@ -146,11 +146,11 @@ Phase A 和 B 可平行開發（前端頁面 + 後端 API 可分工）。Phase C
 
 | 優先級 | 項目 | 需求 ID |
 |--------|------|---------|
-| **P0（已完成）** | JSON 優先輸出 | `CLI-064` ~ `CLI-069` |
-| **P1** | Input Hardening | `CLI-070` ~ `CLI-072` |
-| **P1** | Field Mask | `CLI-073` ~ `CLI-075` |
-| **P2** | Schema Introspection | `CLI-076` ~ `CLI-078` |
-| **P2** | Exit Code 語義化 | `CLI-079` ~ `CLI-080` |
+| **P0（已完成 ✓）** | JSON 優先輸出 | `CLI-064` ~ `CLI-069` |
+| **P1（已完成 ✓）** | Input Hardening | `CLI-070` ~ `CLI-072` |
+| **P1（已完成 ✓）** | Field Mask | `CLI-073` ~ `CLI-075` |
+| **P2（已完成 ✓）** | Schema Introspection | `CLI-076` ~ `CLI-078` |
+| **P2（已完成 ✓）** | Exit Code 語義化 | `CLI-079` ~ `CLI-080` |
 | **P2** | Batch 操作 | `CLI-081` ~ `CLI-082` |
 
 ## Cross-References

--- a/docs/prd/cli-integration/cli.md
+++ b/docs/prd/cli-integration/cli.md
@@ -29,12 +29,15 @@ packages/cli/
 │   │   ├── issues.ts           # issues 子指令
 │   │   ├── issue.ts            # issue 子指令
 │   │   ├── update-status.ts    # update-status 子指令
+│   │   ├── schema.ts           # schema 子指令（Agent introspection）
 │   │   ├── auth.ts             # auth login / status / logout 子指令
 │   │   └── init-skill.ts       # init-skill 子指令
 │   ├── auth/
 │   │   ├── config.ts           # 本地 config 讀寫（~/.config/curl-ticket/config.json）
 │   │   └── device-flow.ts      # Device Code Flow 實作
 │   ├── api-client.ts           # CurlTicketClient（封裝 fetch + auth header）
+│   ├── utils.ts                # ValidationError、normalizeStatus、normalizeType、validateProjectId、parseIssueId
+│   ├── constants.ts            # ExitCode、ISSUE_FIELDS、CLI 設定常數
 │   └── formatters.ts           # JSON → 精簡純文字轉換
 ├── skills/
 │   └── curl-ticket/
@@ -170,6 +173,7 @@ packages/cli/
 {
   "error": true,
   "code": 404,
+  "exitCode": 3,
   "message": "Resource not found."
 }
 ```
@@ -300,8 +304,8 @@ cURL: curl -X POST https://example.com/api/users -H 'Content-Type: application/j
 - `CLI-060`：API 回傳 `403` 時，輸出 `無權限存取此專案。`。
 - `CLI-061`：API 回傳 `404` 時，輸出 `找不到指定的 {resource}。`。
 - `CLI-062`：網路錯誤（fetch 失敗）時，輸出 `無法連線至 {URL}，請確認網址與網路狀態。`。
-- `CLI-063`：所有錯誤訊息輸出至 stderr，以 exit code 1 結束。正常結果輸出至 stdout，以 exit code 0 結束。
-- `CLI-069`：`--json` 模式下，`handleError` 統一提取 error code 與 message，輸出結構化 JSON 至 stderr（避免 pipe 下游收到非預期結構），並以 exit code 1 結束。非 `--json` 模式行為不變。
+- `CLI-063`：所有錯誤訊息輸出至 stderr。正常結果輸出至 stdout，以 exit code 0 結束。錯誤使用語義化 exit code：`0`=成功, `1`=一般錯誤, `2`=認證錯誤(401/403), `3`=資源不存在(404), `4`=輸入驗證錯誤（見 `CLI-079`、`CLI-080`）。
+- `CLI-069`：`--json` 模式下，`handleError` 統一提取 error code 與 message，輸出結構化 JSON（含 `exitCode` 欄位）至 stderr（避免 pipe 下游收到非預期結構），並以對應的語義化 exit code 結束。非 `--json` 模式行為不變。
 
 ---
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -86,6 +86,7 @@ No authentication required. Useful for AI agents to discover available commands 
 | 2 | Authentication / authorization error (401/403) |
 | 3 | Resource not found (404) |
 | 4 | Validation error (invalid input) |
+| 5 | Network connection error |
 
 #### Authentication
 
@@ -207,6 +208,7 @@ ct schema
 | 2 | 認證 / 授權錯誤 (401/403) |
 | 3 | 資源不存在 (404) |
 | 4 | 輸入驗證錯誤 |
+| 5 | 網路連線錯誤 |
 
 #### 認證
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -61,10 +61,31 @@ All data commands support `--json` for structured output, useful for scripts and
 ct projects --json
 ct issues <projectId> --json
 ct issue <projectId> CT-42 --json
+ct issue <projectId> CT-42 --json --fields status,method,url   # Fetch specific fields only
 ct update-status <projectId> <issueId> Done --json
+ct update-status <projectId> <issueId> Done --json --dry-run   # Preview without applying
 ```
 
-JSON responses include full API data and pagination metadata. Errors also return structured JSON when this flag is used.
+JSON responses include full API data and pagination metadata. Errors also return structured JSON (with `exitCode` field) when this flag is used.
+
+#### Schema Introspection
+
+```bash
+# Print full CLI schema (commands, args, options, enums, exit codes, fields)
+ct schema
+```
+
+No authentication required. Useful for AI agents to discover available commands and valid values.
+
+#### Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success |
+| 1 | General error |
+| 2 | Authentication / authorization error (401/403) |
+| 3 | Resource not found (404) |
+| 4 | Validation error (invalid input) |
 
 #### Authentication
 
@@ -161,10 +182,31 @@ ct update-status <projectId> <issueId> Close
 ct projects --json
 ct issues <projectId> --json
 ct issue <projectId> CT-42 --json
+ct issue <projectId> CT-42 --json --fields status,method,url   # 僅取得指定欄位
 ct update-status <projectId> <issueId> Done --json
+ct update-status <projectId> <issueId> Done --json --dry-run   # 預覽變更，不實際執行
 ```
 
-JSON 回應包含完整 API 資料與分頁資訊。啟用此 flag 時，錯誤也會以結構化 JSON 回傳。
+JSON 回應包含完整 API 資料與分頁資訊。啟用此 flag 時，錯誤也會以結構化 JSON（含 `exitCode` 欄位）回傳。
+
+#### Schema 自我描述
+
+```bash
+# 輸出完整 CLI schema（指令、參數、選項、enum 值、exit code、可用欄位）
+ct schema
+```
+
+不需認證。適合 AI Agent 在首次呼叫時探索可用操作與合法值。
+
+#### Exit Code
+
+| 代碼 | 意義 |
+|------|------|
+| 0 | 成功 |
+| 1 | 一般錯誤 |
+| 2 | 認證 / 授權錯誤 (401/403) |
+| 3 | 資源不存在 (404) |
+| 4 | 輸入驗證錯誤 |
 
 #### 認證
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@curl-ticket/cli",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "CLI tool for Curl Ticket — query issues and update status from your terminal",
   "type": "module",
   "license": "MIT",

--- a/packages/cli/skills/curl-ticket/SKILL.md
+++ b/packages/cli/skills/curl-ticket/SKILL.md
@@ -6,6 +6,10 @@ description: >
   issue tracking, analyze bug, update issue status, or requests task information from the issue tracker.
 ---
 
+# First-Run Introspection
+
+Run `curl-ticket schema` to get the full CLI schema — all commands, args, options, enum values, exit codes, and available fields. Use this to avoid invalid inputs and hallucinated values.
+
 # CLI Commands
 
 **Always use `--json` flag** to get structured JSON output. This avoids parsing human-readable text and preserves all fields including pagination.
@@ -14,10 +18,48 @@ description: >
 curl-ticket projects --json                                            # List projects
 curl-ticket issues <projectId> --json [-s Open] [-t api_bug] [-n 10]  # List issues
 curl-ticket issue <projectId> <issueId|CT-42> --json                   # Issue details
+curl-ticket issue <projectId> <issueId> --json --fields status,url,method  # Fetch only specific fields (saves tokens)
 curl-ticket update-status <projectId> <issueId> <status> --json        # Update status (Open|in-progress|Done|Close)
+curl-ticket update-status <projectId> <issueId> <status> --dry-run --json  # Preview without applying
+curl-ticket schema                                                     # Print CLI schema (no auth needed)
 ```
 
 Authentication is handled automatically; first run opens the browser for login.
+
+# Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success |
+| 1 | General error |
+| 2 | Authentication / authorization error (401/403) |
+| 3 | Resource not found (404) |
+| 4 | Validation error (invalid input) |
+
+In `--json` mode, errors include `exitCode` in the response:
+```json
+{ "error": true, "code": 404, "exitCode": 3, "message": "Resource not found." }
+```
+
+# Field Filtering (`--fields`)
+
+Use `--fields` on the `issue` command (JSON mode only) to fetch only the fields you need. This reduces output size and saves context tokens.
+
+```bash
+curl-ticket issue <projectId> CT-1 --json --fields status,method,url,responseStatus
+```
+
+The `id` field is always included. Run `curl-ticket schema` to see all valid field names.
+
+# Dry Run (`--dry-run`)
+
+Use `--dry-run` on `update-status` to preview a mutation without applying it:
+
+```bash
+curl-ticket update-status <projectId> CT-1 Done --dry-run --json
+```
+
+Returns a preview object with `dryRun: true` and the resolved `issueId`, `friendlyId`, and `newStatus`.
 
 # JSON Output Format
 
@@ -31,26 +73,31 @@ Single-resource commands (`issue`, `update-status`) return:
 { "data": { "id": 1, "issueNumber": 42, "issueType": "api_bug", "title": "...", "status": "Open", "method": "GET", "url": "/api/users", "environment": "Prod", "responseStatus": 500, "rawCurl": "...", "responseBody": "...", ... }, "friendlyId": "PROJ-42" }
 ```
 
-Errors return:
-```json
-{ "error": true, "code": 404, "message": "Resource not found." }
-```
+# Input Validation
+
+- `projectId` must be a valid UUID — non-UUID values return exit code 4
+- `--type` must be a valid issue type (`api_bug`, `task`) — invalid values return exit code 4
+- `--status` must be a valid status (`Open`, `in-progress`, `Done`, `Close`) — invalid values return exit code 4
+- `issueId` must be a numeric ID or friendly ID (e.g. `CT-42`) — invalid formats return exit code 4
 
 # Analysis Workflow
 
-1. Run `curl-ticket projects --json` to get the projectId
-2. Run `curl-ticket issues <projectId> -s Open --json` to list open issues
-3. Run `curl-ticket issue <projectId> <issueId> --json` to get full details
-4. Locate code by issue type:
+1. Run `curl-ticket schema` to learn available commands and valid enum values
+2. Run `curl-ticket projects --json` to get the projectId
+3. Run `curl-ticket issues <projectId> -s Open --json` to list open issues
+4. Run `curl-ticket issue <projectId> <issueId> --json --fields status,method,url,responseStatus,rawCurl,responseBody` to get relevant details
+5. Locate code by issue type:
    - **API Bug**: Search for the route handler matching the endpoint field (e.g. `POST /api/users`), then triage by status code:
      - 4xx → validation logic, access control, resource lookup
      - 5xx → application logic errors, DB query issues
    - **Task**: Search codebase using keywords from title and description
-5. Grep for keywords from the error message to pinpoint the failure location
-6. Trace the request chain: route → middleware → handler → business logic → DB query
-7. Provide fix suggestions, then update status with `update-status` after resolving
+6. Grep for keywords from the error message to pinpoint the failure location
+7. Trace the request chain: route → middleware → handler → business logic → DB query
+8. Provide fix suggestions, then update status with `update-status` after resolving
 
 # Constraints
 
 - Always filter with `-s Open` to avoid loading resolved issues
 - Analyze only 1-2 issues at a time to avoid context overload
+- Use `--fields` to fetch only what you need — avoid loading full issue details when a summary suffices
+- Use `--dry-run` before mutations in uncertain contexts

--- a/packages/cli/skills/curl-ticket/SKILL.md
+++ b/packages/cli/skills/curl-ticket/SKILL.md
@@ -35,6 +35,7 @@ Authentication is handled automatically; first run opens the browser for login.
 | 2 | Authentication / authorization error (401/403) |
 | 3 | Resource not found (404) |
 | 4 | Validation error (invalid input) |
+| 5 | Network connection error |
 
 In `--json` mode, errors include `exitCode` in the response:
 ```json

--- a/packages/cli/src/commands/issue.ts
+++ b/packages/cli/src/commands/issue.ts
@@ -21,7 +21,7 @@ export async function issueCommand(
     if (fields) {
       const requested = fields.split(',').map(f => f.trim())
       const validFields = ISSUE_FIELDS as readonly string[]
-      const invalid = requested.filter(f => f !== 'id' && !validFields.includes(f))
+      const invalid = requested.filter(f => !validFields.includes(f))
       if (invalid.length > 0) {
         throw new ValidationError(`Invalid fields: ${invalid.join(', ')}. Valid fields: ${ISSUE_FIELDS.join(', ')}`)
       }

--- a/packages/cli/src/commands/issue.ts
+++ b/packages/cli/src/commands/issue.ts
@@ -1,13 +1,16 @@
 import type { CurlTicketClient } from '../api-client.js'
 import { formatIssueDetail } from '../formatters.js'
-import { parseIssueId } from '../utils.js'
+import { parseIssueId, validateProjectId, ValidationError } from '../utils.js'
+import { ISSUE_FIELDS } from '../constants.js'
 
 export async function issueCommand(
   client: CurlTicketClient,
   projectId: string,
   issueId: string,
-  json = false
+  json = false,
+  fields?: string
 ): Promise<void> {
+  validateProjectId(projectId)
   const parsed = parseIssueId(issueId)
 
   const res = parsed.type === 'id'
@@ -15,7 +18,27 @@ export async function issueCommand(
     : await client.getIssueByNumber(projectId, parsed.value)
 
   if (json) {
-    process.stdout.write(JSON.stringify(res, null, 2) + '\n')
+    if (fields) {
+      const requested = fields.split(',').map(f => f.trim())
+      const validFields = ISSUE_FIELDS as readonly string[]
+      const invalid = requested.filter(f => f !== 'id' && !validFields.includes(f))
+      if (invalid.length > 0) {
+        throw new ValidationError(`Invalid fields: ${invalid.join(', ')}. Valid fields: ${ISSUE_FIELDS.join(', ')}`)
+      }
+
+      // Always include id
+      const fieldSet = new Set(['id', ...requested])
+      const filtered: Record<string, unknown> = {}
+      const data = res.data as unknown as Record<string, unknown>
+      for (const key of fieldSet) {
+        if (key in data) {
+          filtered[key] = data[key]
+        }
+      }
+      process.stdout.write(JSON.stringify({ data: filtered, friendlyId: res.friendlyId }, null, 2) + '\n')
+    } else {
+      process.stdout.write(JSON.stringify(res, null, 2) + '\n')
+    }
     return
   }
 

--- a/packages/cli/src/commands/issues.ts
+++ b/packages/cli/src/commands/issues.ts
@@ -1,6 +1,6 @@
 import type { CurlTicketClient } from '../api-client.js'
 import { formatIssueSummary } from '../formatters.js'
-import { normalizeStatus } from '../utils.js'
+import { normalizeStatus, normalizeType, validateProjectId } from '../utils.js'
 import { DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE } from '../constants.js'
 
 interface IssuesCommandOptions {
@@ -15,12 +15,14 @@ export async function issuesCommand(
   options: IssuesCommandOptions,
   json = false
 ): Promise<void> {
+  validateProjectId(projectId)
   const status = options.status ? normalizeStatus(options.status) : undefined
+  const issueType = options.type ? normalizeType(options.type) : undefined
   const limit = options.limit ? Math.min(options.limit, MAX_PAGE_SIZE) : DEFAULT_PAGE_SIZE
 
   const res = await client.getIssues(projectId, {
     status,
-    issueType: options.type,
+    issueType,
     limit
   })
 

--- a/packages/cli/src/commands/schema.ts
+++ b/packages/cli/src/commands/schema.ts
@@ -1,0 +1,92 @@
+import {
+  IssueStatus,
+  IssueType,
+  Environment,
+  HttpMethod,
+  issueStatuses,
+  issueTypes,
+  environments,
+  httpMethods
+} from '../../../../shared/constants.js'
+import { ExitCode, ISSUE_FIELDS } from '../constants.js'
+
+export function schemaCommand(): void {
+  const schema = {
+    commands: {
+      'projects': {
+        description: 'List accessible projects',
+        args: [],
+        options: {
+          '--json': { type: 'boolean', description: 'Output raw JSON' }
+        }
+      },
+      'issues': {
+        description: 'List issues for a project',
+        args: [
+          { name: 'projectId', type: 'uuid', required: true }
+        ],
+        options: {
+          '--json': { type: 'boolean', description: 'Output raw JSON' },
+          '-s, --status': { type: 'enum', values: ['Open', 'in-progress', 'Done', 'Close'], description: 'Filter by status' },
+          '-t, --type': { type: 'enum', values: issueTypes, description: 'Filter by type' },
+          '-n, --limit': { type: 'number', default: 10, max: 20, description: 'Max results' }
+        }
+      },
+      'issue': {
+        description: 'Get issue details',
+        args: [
+          { name: 'projectId', type: 'uuid', required: true },
+          { name: 'issueId', type: 'string', required: true, description: 'Numeric ID or friendly ID (e.g. CT-42)' }
+        ],
+        options: {
+          '--json': { type: 'boolean', description: 'Output raw JSON' },
+          '--fields': { type: 'string', description: 'Comma-separated fields to include (JSON mode only)', values: [...ISSUE_FIELDS] }
+        }
+      },
+      'update-status': {
+        description: 'Update issue status',
+        args: [
+          { name: 'projectId', type: 'uuid', required: true },
+          { name: 'issueId', type: 'string', required: true, description: 'Numeric ID or friendly ID (e.g. CT-42)' },
+          { name: 'status', type: 'enum', values: ['Open', 'in-progress', 'Done', 'Close'], required: true }
+        ],
+        options: {
+          '--json': { type: 'boolean', description: 'Output raw JSON' },
+          '--dry-run': { type: 'boolean', description: 'Preview update without applying' }
+        }
+      },
+      'schema': {
+        description: 'Print CLI schema for agent introspection',
+        args: [],
+        options: {}
+      },
+      'auth login': {
+        description: 'Log in to Curl Ticket',
+        args: [],
+        options: {
+          '--url': { type: 'string', description: 'Site URL' }
+        }
+      },
+      'auth status': {
+        description: 'Show current login status',
+        args: [],
+        options: {}
+      },
+      'auth logout': {
+        description: 'Log out and delete local config',
+        args: [],
+        options: {}
+      }
+    },
+    enums: {
+      status: { values: issueStatuses, map: IssueStatus },
+      issueType: { values: issueTypes, map: IssueType },
+      environment: { values: environments, map: Environment },
+      httpMethod: { values: httpMethods, map: HttpMethod }
+    },
+    exitCodes: ExitCode,
+    issueFields: [...ISSUE_FIELDS]
+  }
+
+  process.stdout.write(JSON.stringify(schema, null, 2) + '\n')
+}

--- a/packages/cli/src/commands/schema.ts
+++ b/packages/cli/src/commands/schema.ts
@@ -7,8 +7,9 @@ import {
   issueTypes,
   environments,
   httpMethods
-} from '../../../../shared/constants.js'
+} from '#shared/constants.js'
 import { ExitCode, ISSUE_FIELDS } from '../constants.js'
+import { VALID_STATUS_INPUTS } from '../utils.js'
 
 export function schemaCommand(): void {
   const schema = {
@@ -27,7 +28,7 @@ export function schemaCommand(): void {
         ],
         options: {
           '--json': { type: 'boolean', description: 'Output raw JSON' },
-          '-s, --status': { type: 'enum', values: ['Open', 'in-progress', 'Done', 'Close'], description: 'Filter by status' },
+          '-s, --status': { type: 'enum', values: [...VALID_STATUS_INPUTS], description: 'Filter by status' },
           '-t, --type': { type: 'enum', values: issueTypes, description: 'Filter by type' },
           '-n, --limit': { type: 'number', default: 10, max: 20, description: 'Max results' }
         }
@@ -48,7 +49,7 @@ export function schemaCommand(): void {
         args: [
           { name: 'projectId', type: 'uuid', required: true },
           { name: 'issueId', type: 'string', required: true, description: 'Numeric ID or friendly ID (e.g. CT-42)' },
-          { name: 'status', type: 'enum', values: ['Open', 'in-progress', 'Done', 'Close'], required: true }
+          { name: 'status', type: 'enum', values: [...VALID_STATUS_INPUTS], required: true }
         ],
         options: {
           '--json': { type: 'boolean', description: 'Output raw JSON' },
@@ -79,7 +80,7 @@ export function schemaCommand(): void {
       }
     },
     enums: {
-      status: { values: issueStatuses, map: IssueStatus },
+      status: { values: issueStatuses, cliInputs: [...VALID_STATUS_INPUTS], map: IssueStatus },
       issueType: { values: issueTypes, map: IssueType },
       environment: { values: environments, map: Environment },
       httpMethod: { values: httpMethods, map: HttpMethod }

--- a/packages/cli/src/commands/update-status.ts
+++ b/packages/cli/src/commands/update-status.ts
@@ -1,23 +1,44 @@
 import type { CurlTicketClient } from '../api-client.js'
-import { normalizeStatus, parseIssueId } from '../utils.js'
+import { normalizeStatus, parseIssueId, validateProjectId } from '../utils.js'
 
 export async function updateStatusCommand(
   client: CurlTicketClient,
   projectId: string,
   issueId: string,
   status: string,
-  json = false
+  json = false,
+  dryRun = false
 ): Promise<void> {
+  validateProjectId(projectId)
   const normalized = normalizeStatus(status)
   const parsed = parseIssueId(issueId)
 
   // If friendly ID, resolve to actual ID first
   let actualId: string
+  let friendlyId: string | undefined
   if (parsed.type === 'number') {
     const issue = await client.getIssueByNumber(projectId, parsed.value)
     actualId = String(issue.data.id)
+    friendlyId = issue.friendlyId
   } else {
     actualId = parsed.value
+  }
+
+  if (dryRun) {
+    const preview = {
+      dryRun: true,
+      projectId,
+      issueId: actualId,
+      ...(friendlyId ? { friendlyId } : {}),
+      currentAction: 'update-status',
+      newStatus: normalized
+    }
+    if (json) {
+      process.stdout.write(JSON.stringify(preview, null, 2) + '\n')
+    } else {
+      console.log(`[dry-run] Would update issue ${friendlyId ?? actualId} status to "${normalized}"`)
+    }
+    return
   }
 
   const res = await client.updateIssueStatus(projectId, actualId, normalized)

--- a/packages/cli/src/commands/update-status.ts
+++ b/packages/cli/src/commands/update-status.ts
@@ -22,6 +22,10 @@ export async function updateStatusCommand(
     friendlyId = issue.friendlyId
   } else {
     actualId = parsed.value
+    if (dryRun) {
+      const issue = await client.getIssue(projectId, parsed.value)
+      friendlyId = issue.friendlyId
+    }
   }
 
   if (dryRun) {

--- a/packages/cli/src/constants.ts
+++ b/packages/cli/src/constants.ts
@@ -1,6 +1,11 @@
 import { join } from 'node:path'
 import { homedir } from 'node:os'
 
+// Valid issue fields for --fields filtering
+// Type-safe: every entry must be a key of IssueDetail,
+// and every key of IssueDetail must be listed here.
+import type { IssueDetail } from './types.js'
+
 // CLI app name and version
 export const CLI_NAME = 'curl-ticket'
 export const CLI_VERSION = '0.1.0'
@@ -28,3 +33,47 @@ export const BROWSER_COMMANDS: Record<string, string> = {
   linux: 'xdg-open',
   win32: 'start'
 }
+
+// Exit codes
+export const ExitCode = {
+  Success: 0,
+  GeneralError: 1,
+  AuthError: 2,
+  NotFound: 3,
+  ValidationError: 4
+} as const
+
+export type ExitCode = typeof ExitCode[keyof typeof ExitCode]
+
+type AssertExhaustive<
+  T extends readonly string[],
+  U
+> = Exclude<keyof U, T[number]> extends never
+  ? Exclude<T[number], keyof U> extends never
+    ? T
+    : never
+  : never
+
+const _issueFields = [
+  'id',
+  'issueNumber',
+  'projectId',
+  'projectKey',
+  'issueType',
+  'title',
+  'description',
+  'method',
+  'url',
+  'environment',
+  'status',
+  'responseStatus',
+  'rawCurl',
+  'requestHeaders',
+  'requestBody',
+  'responseBody',
+  'createdBy',
+  'createdAt',
+  'updatedAt'
+] as const
+
+export const ISSUE_FIELDS: AssertExhaustive<typeof _issueFields, IssueDetail> = _issueFields

--- a/packages/cli/src/constants.ts
+++ b/packages/cli/src/constants.ts
@@ -8,7 +8,7 @@ import type { IssueDetail } from './types.js'
 
 // CLI app name and version
 export const CLI_NAME = 'curl-ticket'
-export const CLI_VERSION = '0.1.0'
+export const CLI_VERSION = '0.3.0'
 
 // Config file paths
 export const CONFIG_DIR = join(homedir(), '.config', CLI_NAME)

--- a/packages/cli/src/constants.ts
+++ b/packages/cli/src/constants.ts
@@ -40,7 +40,8 @@ export const ExitCode = {
   GeneralError: 1,
   AuthError: 2,
   NotFound: 3,
-  ValidationError: 4
+  ValidationError: 4,
+  NetworkError: 5
 } as const
 
 export type ExitCode = typeof ExitCode[keyof typeof ExitCode]

--- a/packages/cli/src/formatters.ts
+++ b/packages/cli/src/formatters.ts
@@ -1,4 +1,4 @@
-import { IssueType, CurlNoiseHeaders } from '../../../shared/constants.js'
+import { IssueType, CurlNoiseHeaders } from '#shared/constants.js'
 import type { IssueSummary, IssueDetail } from './types.js'
 
 export function truncate(str: string, maxLength: number): string {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,15 +1,17 @@
 import { createInterface } from 'node:readline'
 import { Command } from 'commander'
-import { CurlTicketClient, ApiError, NetworkError } from './api-client.js'
+import { CurlTicketClient, ApiError } from './api-client.js'
 import { getConfigAsync, getUrlAsync } from './auth/config.js'
 import { startDeviceCodeFlow } from './auth/device-flow.js'
 import { projectsCommand } from './commands/projects.js'
 import { issuesCommand } from './commands/issues.js'
 import { issueCommand } from './commands/issue.js'
 import { updateStatusCommand } from './commands/update-status.js'
+import { schemaCommand } from './commands/schema.js'
 import { authLoginCommand, authStatusCommand, authLogoutCommand } from './commands/auth.js'
 import { initSkillCommand } from './commands/init-skill/index.js'
-import { CLI_NAME, CLI_VERSION, DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE } from './constants.js'
+import { ValidationError } from './utils.js'
+import { CLI_NAME, CLI_VERSION, DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE, ExitCode } from './constants.js'
 import type { AuthConfig } from './types.js'
 
 function promptUrl(): Promise<string> {
@@ -62,37 +64,39 @@ async function withAuth<T>(fn: (client: CurlTicketClient) => Promise<T>): Promis
   }
 }
 
-function handleError(err: unknown, json = false): never {
-  let code: number | null = null
-  let message = 'An unknown error occurred.'
+interface ErrorInfo {
+  code: number | null
+  exitCode: ExitCode
+  message: string
+}
 
+const API_STATUS_MAP: Record<number, ErrorInfo> = {
+  401: { code: 401, exitCode: ExitCode.AuthError, message: 'Invalid token. Please regenerate it from the Curl Ticket site.' },
+  403: { code: 403, exitCode: ExitCode.AuthError, message: 'Access denied for this project.' },
+  404: { code: 404, exitCode: ExitCode.NotFound, message: 'Resource not found.' }
+}
+
+function resolveError(err: unknown): ErrorInfo {
   if (err instanceof ApiError) {
-    code = err.statusCode
-    switch (err.statusCode) {
-      case 401:
-        message = 'Invalid token. Please regenerate it from the Curl Ticket site.'
-        break
-      case 403:
-        message = 'Access denied for this project.'
-        break
-      case 404:
-        message = 'Resource not found.'
-        break
-      default:
-        message = `API error (${err.statusCode}): ${err.message}`
-    }
-  } else if (err instanceof NetworkError) {
-    message = err.message
-  } else if (err instanceof Error) {
-    message = err.message
+    return API_STATUS_MAP[err.statusCode]
+      ?? { code: err.statusCode, exitCode: ExitCode.GeneralError, message: `API error (${err.statusCode}): ${err.message}` }
   }
+  if (err instanceof ValidationError) {
+    return { code: null, exitCode: ExitCode.ValidationError, message: err.message }
+  }
+  const message = err instanceof Error ? err.message : 'An unknown error occurred.'
+  return { code: null, exitCode: ExitCode.GeneralError, message }
+}
+
+function handleError(err: unknown, json = false): never {
+  const { code, exitCode, message } = resolveError(err)
 
   if (json) {
-    process.stderr.write(JSON.stringify({ error: true, code, message }, null, 2) + '\n')
+    process.stderr.write(JSON.stringify({ error: true, code, exitCode, message }, null, 2) + '\n')
   } else {
     process.stderr.write(message + '\n')
   }
-  process.exit(1)
+  process.exit(exitCode)
 }
 
 const program = new Command()
@@ -141,9 +145,10 @@ program
 program
   .command('issue <projectId> <issueId>')
   .description('Get issue details')
-  .action(async (projectId: string, issueId: string) => {
+  .option('--fields <fields>', 'Comma-separated list of fields to include (JSON mode only)')
+  .action(async (projectId: string, issueId: string, options: { fields?: string }) => {
     try {
-      await withAuth(client => issueCommand(client, projectId, issueId, isJsonMode()))
+      await withAuth(client => issueCommand(client, projectId, issueId, isJsonMode(), options.fields))
     } catch (err) {
       handleError(err, isJsonMode())
     }
@@ -152,9 +157,23 @@ program
 program
   .command('update-status <projectId> <issueId> <status>')
   .description('Update issue status')
-  .action(async (projectId: string, issueId: string, status: string) => {
+  .option('--dry-run', 'Preview the update without applying it')
+  .action(async (projectId: string, issueId: string, status: string, options: { dryRun?: boolean }) => {
     try {
-      await withAuth(client => updateStatusCommand(client, projectId, issueId, status, isJsonMode()))
+      await withAuth(client => updateStatusCommand(client, projectId, issueId, status, isJsonMode(), options.dryRun))
+    } catch (err) {
+      handleError(err, isJsonMode())
+    }
+  })
+
+// --- Schema introspection ---
+
+program
+  .command('schema')
+  .description('Print CLI schema for agent introspection')
+  .action(() => {
+    try {
+      schemaCommand()
     } catch (err) {
       handleError(err, isJsonMode())
     }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,6 +1,6 @@
 import { createInterface } from 'node:readline'
 import { Command } from 'commander'
-import { CurlTicketClient, ApiError } from './api-client.js'
+import { CurlTicketClient, ApiError, NetworkError } from './api-client.js'
 import { getConfigAsync, getUrlAsync } from './auth/config.js'
 import { startDeviceCodeFlow } from './auth/device-flow.js'
 import { projectsCommand } from './commands/projects.js'
@@ -80,6 +80,9 @@ function resolveError(err: unknown): ErrorInfo {
   if (err instanceof ApiError) {
     return API_STATUS_MAP[err.statusCode]
       ?? { code: err.statusCode, exitCode: ExitCode.GeneralError, message: `API error (${err.statusCode}): ${err.message}` }
+  }
+  if (err instanceof NetworkError) {
+    return { code: null, exitCode: ExitCode.NetworkError, message: err.message }
   }
   if (err instanceof ValidationError) {
     return { code: null, exitCode: ExitCode.ValidationError, message: err.message }

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -1,4 +1,4 @@
-import type { IssueType, IssueStatus } from '../../../shared/constants.js'
+import type { IssueType, IssueStatus } from '#shared/constants.js'
 
 export interface Project {
   id: string

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -1,4 +1,11 @@
-import { IssueStatus } from '../../../shared/constants.js'
+import { IssueStatus, issueTypes } from '../../../shared/constants.js'
+
+export class ValidationError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'ValidationError'
+  }
+}
 
 const STATUS_ALIASES: Record<string, IssueStatus> = {
   'open': IssueStatus.Open,
@@ -13,7 +20,7 @@ const VALID_STATUS_INPUTS = ['Open', 'in-progress', 'Done', 'Close']
 export function normalizeStatus(status: string): IssueStatus {
   const normalized = STATUS_ALIASES[status.toLowerCase()]
   if (!normalized) {
-    throw new Error(`Invalid status. Valid values: ${VALID_STATUS_INPUTS.join(', ')}`)
+    throw new ValidationError(`Invalid status. Valid values: ${VALID_STATUS_INPUTS.join(', ')}`)
   }
   return normalized
 }
@@ -26,5 +33,22 @@ export function parseIssueId(issueId: string): { type: 'id', value: string } | {
   if (match) {
     return { type: 'number', value: parseInt(match[1], 10) }
   }
-  throw new Error(`Invalid issue ID format: ${issueId}. Use a numeric ID or friendly ID (e.g. CT-42).`)
+  throw new ValidationError(`Invalid issue ID format: ${issueId}. Use a numeric ID or friendly ID (e.g. CT-42).`)
+}
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+export function validateProjectId(projectId: string): void {
+  if (!UUID_RE.test(projectId)) {
+    throw new ValidationError(`Invalid projectId: "${projectId}" is not a valid UUID.`)
+  }
+}
+
+export function normalizeType(type: string): string {
+  const lower = type.toLowerCase().replace(/-/g, '_')
+  const valid = issueTypes as readonly string[]
+  if (!valid.includes(lower)) {
+    throw new ValidationError(`Invalid type "${type}". Valid values: ${issueTypes.join(', ')}`)
+  }
+  return lower
 }

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -1,4 +1,5 @@
-import { IssueStatus, issueTypes } from '../../../shared/constants.js'
+import { IssueStatus, issueTypes } from '#shared/constants.js'
+import type { IssueType } from '#shared/constants.js'
 
 export class ValidationError extends Error {
   constructor(message: string) {
@@ -15,7 +16,7 @@ const STATUS_ALIASES: Record<string, IssueStatus> = {
   'close': IssueStatus.Close
 }
 
-const VALID_STATUS_INPUTS = ['Open', 'in-progress', 'Done', 'Close']
+export const VALID_STATUS_INPUTS = ['Open', 'in-progress', 'Done', 'Close'] as const
 
 export function normalizeStatus(status: string): IssueStatus {
   const normalized = STATUS_ALIASES[status.toLowerCase()]
@@ -44,11 +45,11 @@ export function validateProjectId(projectId: string): void {
   }
 }
 
-export function normalizeType(type: string): string {
+export function normalizeType(type: string): IssueType {
   const lower = type.toLowerCase().replace(/-/g, '_')
   const valid = issueTypes as readonly string[]
   if (!valid.includes(lower)) {
     throw new ValidationError(`Invalid type "${type}". Valid values: ${issueTypes.join(', ')}`)
   }
-  return lower
+  return lower as IssueType
 }

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -9,7 +9,11 @@
     "rootDir": "../../",
     "outDir": "dist",
     "declaration": false,
-    "sourceMap": true
+    "sourceMap": true,
+    "baseUrl": ".",
+    "paths": {
+      "#shared/*": ["../../shared/*"]
+    }
   },
   "include": ["src", "../../shared"]
 }

--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -7,5 +7,10 @@ export default defineConfig({
   clean: true,
   banner: {
     js: '#!/usr/bin/env node'
+  },
+  esbuildOptions(options) {
+    options.alias = {
+      '#shared': '../../shared'
+    }
   }
 })


### PR DESCRIPTION
## Summary
- Add `schema` command for agent introspection (outputs full CLI schema as JSON)
- Add input validation: UUID check for projectId, `ValidationError` class
- Add structured exit codes (0-5: Success, GeneralError, AuthError, NotFound, ValidationError, NetworkError)
- Add `--fields` flag on `issue` command for JSON field filtering
- Add `--dry-run` flag on `update-status` command
- Unify shared imports with `#shared` path alias
- Bump CLI version to 0.3.0

## Test plan
- [x] `schema` command outputs valid JSON with all commands, enums, exit codes
- [x] Invalid UUID projectId returns exit code 4 with clear message
- [x] Invalid status returns exit code 4
- [x] `--fields title,status` returns only requested fields + id
- [x] `--fields bogus` returns validation error
- [x] `--dry-run` previews update without applying (text & JSON mode)
- [x] JSON error output writes structured error to stderr

🤖 Generated with [Claude Code](https://claude.com/claude-code)