### PR TITLE
feat: add i18n-aware form validation with locale messages

### DIFF
--- a/app/components/IssueForm.vue
+++ b/app/components/IssueForm.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { Environment, HttpMethod, IssueStatus, IssueType } from '~~/shared/constants'
-import { createApiBugFormSchema, createTaskFormSchema } from '~~/shared/schemas/issue'
 import { formatJson } from '~/utils/issue'
+import { createApiBugValidationSchema, createTaskValidationSchema } from '~/utils/validation'
 import { issueTypeTabs } from '~/constants/issue'
 import type { FormSubmitEvent } from '@nuxt/ui'
 import type { IssueResponse } from '~/types/issue'
@@ -144,7 +144,9 @@ watch(curlInput, (value) => {
 // Dynamic schema based on issue type
 // 編輯模式也用 create schema 驗證必填欄位，.partial() 的 updateIssueSchema 只給 API PATCH 用
 const activeSchema = computed(() => {
-  return activeIssueType.value === IssueType.Task ? createTaskFormSchema : createApiBugFormSchema
+  return activeIssueType.value === IssueType.Task
+    ? createTaskValidationSchema(t)
+    : createApiBugValidationSchema(t)
 })
 
 // Active form state for UForm binding

--- a/app/components/ProjectForm.vue
+++ b/app/components/ProjectForm.vue
@@ -3,7 +3,7 @@ import type { FormSubmitEvent } from '@nuxt/ui'
 import type { CreateProjectInput } from '~~/shared/schemas/project'
 import type { Environment } from '~~/shared/constants'
 import { environments } from '~~/shared/constants'
-import { createProjectSchema } from '~~/shared/schemas/project'
+import { createProjectFormSchema } from '~/utils/validation'
 
 type ProjectFormMode = 'create' | 'edit'
 
@@ -30,6 +30,7 @@ const emit = defineEmits<{
 const state = defineModel<CreateProjectInput>('state', { required: true })
 
 const { t } = useI18n()
+const formSchema = computed(() => createProjectFormSchema(t))
 
 const isEditMode = computed(() => props.mode === 'edit')
 const keyDescription = computed(() =>
@@ -85,7 +86,7 @@ function onSubmit(_event: FormSubmitEvent<CreateProjectInput>) {
       </template>
 
       <UForm
-        :schema="createProjectSchema"
+        :schema="formSchema"
         :state="state"
         class="flex flex-col gap-6"
         @submit="onSubmit"

--- a/app/pages/projects/[id]/members.vue
+++ b/app/pages/projects/[id]/members.vue
@@ -3,11 +3,11 @@ import { InvitationStatusColor, type BadgeColor } from '~/constants/invitation'
 import type { InvitationStatus } from '~~/shared/constants'
 import type { ProjectMember } from '~~/shared/schemas/project'
 import {
-  createProjectInvitationSchema,
   type CreateProjectInvitationInput,
   type ProjectInvitation
 } from '~~/shared/schemas/project-invitation'
 import type { FormSubmitEvent } from '@nuxt/ui'
+import { createProjectInvitationFormSchema } from '~/utils/validation'
 
 definePageMeta({
   ssr: false
@@ -15,6 +15,7 @@ definePageMeta({
 
 const route = useRoute()
 const { t } = useI18n()
+const formSchema = computed(() => createProjectInvitationFormSchema(t))
 const toast = useToast()
 const projectId = computed(() => route.params.id as string)
 const user = useSupabaseUser()
@@ -178,7 +179,7 @@ function getStatusColor(status: InvitationStatus): BadgeColor {
                 {{ $t('members.inviteMembers') }}
               </h2>
               <UForm
-                :schema="createProjectInvitationSchema"
+                :schema="formSchema"
                 :state="inviteState"
                 class="flex items-start gap-2"
                 @submit="sendInvitation"

--- a/app/pages/projects/[id]/members.vue
+++ b/app/pages/projects/[id]/members.vue
@@ -2,9 +2,9 @@
 import { InvitationStatusColor, type BadgeColor } from '~/constants/invitation'
 import type { InvitationStatus } from '~~/shared/constants'
 import type { ProjectMember } from '~~/shared/schemas/project'
-import {
-  type CreateProjectInvitationInput,
-  type ProjectInvitation
+import type {
+  CreateProjectInvitationInput,
+  ProjectInvitation
 } from '~~/shared/schemas/project-invitation'
 import type { FormSubmitEvent } from '@nuxt/ui'
 import { createProjectInvitationFormSchema } from '~/utils/validation'

--- a/app/pages/register.vue
+++ b/app/pages/register.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { PENDING_INVITATION_TOKEN_KEY } from '~~/app/constants/auth'
-import {
-  type ValidateInvitationCodeInput
+import type {
+  ValidateInvitationCodeInput
 } from '~~/shared/schemas/invitation-code'
 import type { FormSubmitEvent } from '@nuxt/ui'
 import { createInvitationCodeFormSchema } from '~/utils/validation'

--- a/app/pages/register.vue
+++ b/app/pages/register.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
 import { PENDING_INVITATION_TOKEN_KEY } from '~~/app/constants/auth'
 import {
-  validateInvitationCodeSchema,
   type ValidateInvitationCodeInput
 } from '~~/shared/schemas/invitation-code'
 import type { FormSubmitEvent } from '@nuxt/ui'
+import { createInvitationCodeFormSchema } from '~/utils/validation'
 
 definePageMeta({
   layout: 'header-only'
@@ -20,6 +20,7 @@ const valid = ref(false)
 const errorMessage = ref('')
 
 const { t } = useI18n()
+const formSchema = computed(() => createInvitationCodeFormSchema(t))
 const { fetchProfile, clearProfile } = useProfile()
 
 // 已登入且有 profile 才導回首頁；已登入但無 profile 留在此頁繼續輸入邀請碼
@@ -172,7 +173,7 @@ async function signInWithGoogle() {
         </div>
 
         <UForm
-          :schema="validateInvitationCodeSchema"
+          :schema="formSchema"
           :state="codeState"
           class="flex w-full flex-col items-center gap-4"
           @submit="validateCode"

--- a/app/pages/register.vue
+++ b/app/pages/register.vue
@@ -1,8 +1,6 @@
 <script setup lang="ts">
 import { PENDING_INVITATION_TOKEN_KEY } from '~~/app/constants/auth'
-import type {
-  ValidateInvitationCodeInput
-} from '~~/shared/schemas/invitation-code'
+import type { ValidateInvitationCodeInput } from '~~/shared/schemas/invitation-code'
 import type { FormSubmitEvent } from '@nuxt/ui'
 import { createInvitationCodeFormSchema } from '~/utils/validation'
 

--- a/app/utils/validation.ts
+++ b/app/utils/validation.ts
@@ -1,0 +1,79 @@
+import { z } from 'zod'
+import {
+  Environment,
+  environments,
+  httpMethods,
+  IssueStatus,
+  issueStatuses
+} from '~~/shared/constants'
+
+type Translate = (key: string, params?: Record<string, unknown>) => string
+
+export function createProjectFormSchema(t: Translate) {
+  return z.object({
+    name: z
+      .string()
+      .min(1, t('validation.project.name.required'))
+      .max(100, t('validation.project.name.max')),
+    key: z
+      .string()
+      .min(2, t('validation.project.key.min'))
+      .max(10, t('validation.project.key.max'))
+      .regex(/^[A-Z0-9]+$/, t('validation.project.key.format')),
+    description: z.string().nullish(),
+    environments: z
+      .array(z.enum(environments))
+      .min(1, t('validation.project.environments.required'))
+  })
+}
+
+export function createInvitationCodeFormSchema(t: Translate) {
+  return z.object({
+    code: z.string().length(6, t('validation.invitationCode.invalidLength'))
+  })
+}
+
+export function createProjectInvitationFormSchema(t: Translate) {
+  return z.object({
+    email: z.email(t('validation.projectInvitation.email.invalid'))
+  })
+}
+
+export function createTaskValidationSchema(t: Translate) {
+  return z.object({
+    title: z
+      .string()
+      .min(1, t('validation.issue.title.required'))
+      .max(200, t('validation.issue.title.max')),
+    description: z.string().nullish(),
+    status: z.enum(issueStatuses).default(IssueStatus.Open)
+  })
+}
+
+export function createApiBugValidationSchema(t: Translate) {
+  return z.object({
+    title: z
+      .string()
+      .min(1, t('validation.issue.title.required'))
+      .max(200, t('validation.issue.title.max')),
+    description: z.string().nullish(),
+    rawCurl: z.string().nullish(),
+    method: z.enum(httpMethods, {
+      message: t('validation.issue.method.invalid')
+    }),
+    url: z.string().min(1, t('validation.issue.url.required')),
+    environment: z
+      .enum(environments)
+      .default(Environment.Dev),
+    requestHeaders: z.record(z.string(), z.string()).nullish(),
+    requestBody: z.unknown().nullish(),
+    responseStatus: z
+      .number(t('validation.issue.responseStatus.invalid'))
+      .int()
+      .min(100, t('validation.issue.responseStatus.invalid'))
+      .max(599, t('validation.issue.responseStatus.invalid'))
+      .nullish(),
+    responseBody: z.unknown().nullish(),
+    status: z.enum(issueStatuses).default(IssueStatus.Open)
+  })
+}

--- a/app/utils/validation.ts
+++ b/app/utils/validation.ts
@@ -62,9 +62,7 @@ export function createApiBugValidationSchema(t: Translate) {
       message: t('validation.issue.method.invalid')
     }),
     url: z.string().min(1, t('validation.issue.url.required')),
-    environment: z
-      .enum(environments)
-      .default(Environment.Dev),
+    environment: z.enum(environments).default(Environment.Dev),
     requestHeaders: z.record(z.string(), z.string()).nullish(),
     requestBody: z.unknown().nullish(),
     responseStatus: z

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -25,6 +25,45 @@
     "noDescription": "No description provided",
     "lines": "{count} lines"
   },
+  "validation": {
+    "issue": {
+      "title": {
+        "required": "Issue title is required",
+        "max": "Issue title must be 200 characters or less"
+      },
+      "method": {
+        "invalid": "Invalid HTTP method"
+      },
+      "url": {
+        "required": "URL is required"
+      },
+      "responseStatus": {
+        "invalid": "Invalid status code"
+      }
+    },
+    "project": {
+      "name": {
+        "required": "Project name is required",
+        "max": "Project name must be 100 characters or less"
+      },
+      "key": {
+        "min": "Project key must be at least 2 characters",
+        "max": "Project key must be 10 characters or less",
+        "format": "Project key can only contain uppercase letters and numbers"
+      },
+      "environments": {
+        "required": "Please select at least one environment"
+      }
+    },
+    "invitationCode": {
+      "invalidLength": "Invitation code must be 6 alphanumeric characters"
+    },
+    "projectInvitation": {
+      "email": {
+        "invalid": "Please enter a valid email address"
+      }
+    }
+  },
   "locale": {
     "en": "English",
     "zhTW": "繁體中文"

--- a/i18n/locales/zh-TW.json
+++ b/i18n/locales/zh-TW.json
@@ -25,6 +25,45 @@
     "noDescription": "尚無描述",
     "lines": "{count} 行"
   },
+  "validation": {
+    "issue": {
+      "title": {
+        "required": "Issue 標題不可為空",
+        "max": "Issue 標題不可超過 200 字"
+      },
+      "method": {
+        "invalid": "無效的 HTTP 方法"
+      },
+      "url": {
+        "required": "URL 不可為空"
+      },
+      "responseStatus": {
+        "invalid": "無效的狀態碼"
+      }
+    },
+    "project": {
+      "name": {
+        "required": "Project 名稱不可為空",
+        "max": "Project 名稱不可超過 100 字"
+      },
+      "key": {
+        "min": "Project Key 至少 2 個字元",
+        "max": "Project Key 不可超過 10 個字元",
+        "format": "Project Key 只能包含大寫字母和數字"
+      },
+      "environments": {
+        "required": "請至少選擇一個 Environment"
+      }
+    },
+    "invitationCode": {
+      "invalidLength": "邀請碼為 6 位英數字"
+    },
+    "projectInvitation": {
+      "email": {
+        "invalid": "請輸入有效的 Email"
+      }
+    }
+  },
   "locale": {
     "en": "English",
     "zhTW": "繁體中文"

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -1,39 +1,36 @@
 // ============================================
 // Issue 類型定義
 // ============================================
+export const issueTypes = ['api_bug', 'task'] as const
+export type IssueType = (typeof issueTypes)[number]
 export const IssueType = {
   ApiBug: 'api_bug',
   Task: 'task'
-} as const
-
-export type IssueType = (typeof IssueType)[keyof typeof IssueType]
-export const issueTypes = Object.values(IssueType)
+} as const satisfies Record<string, IssueType>
 
 // ============================================
 // Environment 環境定義
 // ============================================
+export const environments = ['Local', 'Dev', 'Staging', 'Prod'] as const
+export type Environment = (typeof environments)[number]
 export const Environment = {
   Local: 'Local',
   Dev: 'Dev',
   Staging: 'Staging',
   Prod: 'Prod'
-} as const
-
-export type Environment = (typeof Environment)[keyof typeof Environment]
-export const environments = Object.values(Environment)
+} as const satisfies Record<string, Environment>
 
 // ============================================
 // Issue 狀態定義
 // ============================================
+export const issueStatuses = ['Open', 'In Progress', 'Done', 'Close'] as const
+export type IssueStatus = (typeof issueStatuses)[number]
 export const IssueStatus = {
   Open: 'Open',
   InProgress: 'In Progress',
   Done: 'Done',
   Close: 'Close'
-} as const
-
-export type IssueStatus = (typeof IssueStatus)[keyof typeof IssueStatus]
-export const issueStatuses = Object.values(IssueStatus)
+} as const satisfies Record<string, IssueStatus>
 
 // ============================================
 // HTTP 狀態碼定義
@@ -51,6 +48,8 @@ export type HttpStatus = (typeof HttpStatus)[keyof typeof HttpStatus]
 // ============================================
 // HTTP 方法定義
 // ============================================
+export const httpMethods = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS'] as const
+export type HttpMethod = (typeof httpMethods)[number]
 export const HttpMethod = {
   GET: 'GET',
   POST: 'POST',
@@ -59,34 +58,29 @@ export const HttpMethod = {
   DELETE: 'DELETE',
   HEAD: 'HEAD',
   OPTIONS: 'OPTIONS'
-} as const
-
-export type HttpMethod = (typeof HttpMethod)[keyof typeof HttpMethod]
-export const httpMethods = Object.values(HttpMethod)
+} as const satisfies Record<string, HttpMethod>
 
 // ============================================
 // 用戶角色定義
 // ============================================
+export const userRoles = ['admin', 'user'] as const
+export type UserRole = (typeof userRoles)[number]
 export const UserRole = {
   Admin: 'admin',
   User: 'user'
-} as const
-
-export type UserRole = (typeof UserRole)[keyof typeof UserRole]
-export const userRoles = Object.values(UserRole)
+} as const satisfies Record<string, UserRole>
 
 // ============================================
 // 邀請狀態定義
 // ============================================
+export const invitationStatuses = ['pending', 'accepted', 'rejected', 'expired'] as const
+export type InvitationStatus = (typeof invitationStatuses)[number]
 export const InvitationStatus = {
   Pending: 'pending',
   Accepted: 'accepted',
   Rejected: 'rejected',
   Expired: 'expired'
-} as const
-
-export type InvitationStatus = (typeof InvitationStatus)[keyof typeof InvitationStatus]
-export const invitationStatuses = Object.values(InvitationStatus)
+} as const satisfies Record<string, InvitationStatus>
 
 // ============================================
 // 通知類型定義

--- a/shared/schemas/api-token.ts
+++ b/shared/schemas/api-token.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod'
 
 export const createTokenSchema = z.object({
-  name: z.string().min(1, '名稱不可為空').max(100, '名稱不可超過 100 字'),
+  name: z.string().min(1, 'Name is required').max(100, 'Name must be 100 characters or less'),
   expiresInDays: z.number().int().min(1).max(365).nullish()
 })
 

--- a/shared/schemas/invitation-code.ts
+++ b/shared/schemas/invitation-code.ts
@@ -5,7 +5,7 @@ export const createInvitationCodeSchema = z.object({
 })
 
 export const validateInvitationCodeSchema = z.object({
-  code: z.string().length(6, '邀請碼為 6 位英數字')
+  code: z.string().length(6, 'Invitation code must be 6 alphanumeric characters')
 })
 
 export type CreateInvitationCodeInput = z.infer<typeof createInvitationCodeSchema>

--- a/shared/schemas/issue.ts
+++ b/shared/schemas/issue.ts
@@ -16,7 +16,7 @@ import {
 /** Base fields shared by both issue types */
 const issueBaseFields = {
   projectId: z.uuid(),
-  title: z.string().min(1, '標題不可為空').max(200, '標題不可超過 200 字'),
+  title: z.string().min(1, 'Title is required').max(200, 'Title must be 200 characters or less'),
   description: z.string().nullish(),
   status: z.enum(issueStatuses).default(IssueStatus.Open)
 }
@@ -25,16 +25,16 @@ const issueBaseFields = {
 const apiBugFields = {
   issueType: z.literal(IssueType.ApiBug),
   rawCurl: z.string().nullish(),
-  method: z.enum(httpMethods, { message: '無效的 HTTP 方法' }),
-  url: z.string().min(1, 'URL 不可為空'),
+  method: z.enum(httpMethods, { message: 'Invalid HTTP method' }),
+  url: z.string().min(1, 'URL is required'),
   environment: z.enum(environments).default(Environment.Dev),
   requestHeaders: z.record(z.string(), z.string()).nullish(),
   requestBody: z.unknown().nullish(),
   responseStatus: z
-    .number('無效的狀態碼')
+    .number('Invalid status code')
     .int()
-    .min(100, '無效的狀態碼')
-    .max(599, '無效的狀態碼')
+    .min(100, 'Invalid status code')
+    .max(599, 'Invalid status code')
     .nullish(),
   responseBody: z.unknown().nullish()
 }
@@ -100,7 +100,7 @@ export const createTaskFormSchema = z
 
 /** Base fields for update (no defaults, so .partial() works correctly) */
 const issueBaseUpdateFields = {
-  title: z.string().min(1, '標題不可為空').max(200, '標題不可超過 200 字'),
+  title: z.string().min(1, 'Title is required').max(200, 'Title must be 200 characters or less'),
   description: z.string().nullish(),
   status: z.enum(issueStatuses)
 }

--- a/shared/schemas/project-invitation.ts
+++ b/shared/schemas/project-invitation.ts
@@ -2,7 +2,7 @@ import { z } from 'zod'
 import { invitationStatuses } from '../constants'
 
 export const createProjectInvitationSchema = z.object({
-  email: z.email('請輸入有效的 Email')
+  email: z.email('Please enter a valid email address')
 })
 
 export const respondProjectInvitationSchema = z.object({

--- a/shared/schemas/project.ts
+++ b/shared/schemas/project.ts
@@ -7,14 +7,19 @@ import { environments } from '../constants'
 
 /** 新增專案 */
 export const createProjectSchema = z.object({
-  name: z.string().min(1, '專案名稱不可為空').max(100, '專案名稱不可超過 100 字'),
+  name: z
+    .string()
+    .min(1, 'Project name is required')
+    .max(100, 'Project name must be 100 characters or less'),
   key: z
     .string()
-    .min(2, '專案代號至少 2 個字元')
-    .max(10, '專案代號不可超過 10 個字元')
-    .regex(/^[A-Z0-9]+$/, '專案代號只能包含大寫字母和數字'),
+    .min(2, 'Project key must be at least 2 characters')
+    .max(10, 'Project key must be 10 characters or less')
+    .regex(/^[A-Z0-9]+$/, 'Project key can only contain uppercase letters and numbers'),
   description: z.string().nullish(),
-  environments: z.array(z.enum(environments as [string, ...string[]])).min(1, '請至少選擇一個環境')
+  environments: z
+    .array(z.enum(environments))
+    .min(1, 'Please select at least one environment')
 })
 
 export const editableProjectSchema = createProjectSchema.pick({
@@ -33,7 +38,7 @@ export const projectSchema = z.object({
   name: z.string(),
   key: z.string(),
   description: z.string().nullable(),
-  environments: z.array(z.string()),
+  environments: z.array(z.enum(environments)),
   createdAt: z.coerce.date()
 })
 

--- a/shared/schemas/project.ts
+++ b/shared/schemas/project.ts
@@ -17,9 +17,7 @@ export const createProjectSchema = z.object({
     .max(10, 'Project key must be 10 characters or less')
     .regex(/^[A-Z0-9]+$/, 'Project key can only contain uppercase letters and numbers'),
   description: z.string().nullish(),
-  environments: z
-    .array(z.enum(environments))
-    .min(1, 'Please select at least one environment')
+  environments: z.array(z.enum(environments)).min(1, 'Please select at least one environment')
 })
 
 export const editableProjectSchema = createProjectSchema.pick({


### PR DESCRIPTION
## Summary

- Introduces locale-aware form validation by extracting Zod schemas into `app/utils/validation.ts` factory functions that accept a `t()` translator, so validation error messages are displayed in the user's locale
- Normalizes all shared Zod schema error messages from Chinese to English fallbacks, keeping server-side validation consistent and language-neutral
- Refactors shared constants to declare canonical `as const` arrays first and derive the object/type from them, enabling direct use with `z.enum()` without casting

## Type of Change

- [x] feat: new feature

## Related Issues

<!-- Link related issues: closes #123, fixes #456 -->

## Test Plan

- [x] Tested locally
- [x] Lint passes (`pnpm lint`)
- [x] Typecheck passes (`pnpm typecheck`)