### PR TITLE
feat(notifications): add issue navigation and bulk mark-as-read

### DIFF
--- a/app/components/NotificationBell.vue
+++ b/app/components/NotificationBell.vue
@@ -1,10 +1,13 @@
 <script setup lang="ts">
 import { NotificationType, InvitationStatus } from '~~/shared/constants'
 import { PROJECTS_CACHE_KEY } from '~/composables/useProjects'
+import type { NotificationItem } from '~~/shared/types'
 
-const { notifications, unreadCount, refresh, markAsRead } = useNotifications()
+const { t } = useI18n()
+const { notifications, unreadCount, refresh, markAsRead, markAllAsRead } = useNotifications()
 
 const popoverOpen = ref(false)
+const markAllLoading = ref(false)
 
 // Invitation modal state
 const invitationModalOpen = ref(false)
@@ -14,40 +17,69 @@ const selectedInvitation = ref<{
   content: string | null
 } | null>(null)
 
-function handleNotificationClick(notification: (typeof notifications.value)[number]) {
-  if (notification.type === NotificationType.ProjectInvite) {
-    if (
-      notification.projectInvitationId &&
-      notification.invitationStatus === InvitationStatus.Pending
-    ) {
-      selectedInvitation.value = {
-        projectInvitationId: notification.projectInvitationId,
-        projectName: notification.projectName,
-        content: notification.content
-      }
-      invitationModalOpen.value = true
-      popoverOpen.value = false
-      if (!notification.isRead) {
-        markAsRead(notification.id)
-      }
-      return
-    }
-
-    if (!notification.isRead) {
-      markAsRead(notification.id)
-    }
-    popoverOpen.value = false
-  } else if (notification.issueId) {
-    if (!notification.isRead) {
-      markAsRead(notification.id)
-    }
-    popoverOpen.value = false
+function dismissAndRead(notification: NotificationItem) {
+  popoverOpen.value = false
+  if (!notification.isRead) {
+    void markAsRead(notification.id)
   }
+}
+
+function handleNotificationClick(notification: NotificationItem) {
+  const { type } = notification
+
+  if (type === NotificationType.ProjectInvite) {
+    return handleProjectInviteClick(notification)
+  }
+
+  if (type === NotificationType.IssueUpdate || type === NotificationType.IssueComment) {
+    return handleIssueClick(notification)
+  }
+}
+
+function handleProjectInviteClick(notification: NotificationItem) {
+  dismissAndRead(notification)
+
+  if (
+    notification.projectInvitationId &&
+    notification.invitationStatus === InvitationStatus.Pending
+  ) {
+    selectedInvitation.value = {
+      projectInvitationId: notification.projectInvitationId,
+      projectName: notification.projectName,
+      content: notification.content
+    }
+    invitationModalOpen.value = true
+  }
+}
+
+function handleIssueClick(notification: NotificationItem) {
+  if (!notification.issueId) return
+
+  dismissAndRead(notification)
+
+  if (!notification.issueProjectId) {
+    const toast = useToast()
+    toast.add({ title: t('notifications.issueUnavailable'), color: 'warning' })
+    return
+  }
+
+  void navigateTo(`/projects/${notification.issueProjectId}/issues/${notification.issueId}`)
 }
 
 function onInvitationResponded() {
   refresh()
   void refreshNuxtData(PROJECTS_CACHE_KEY)
+}
+
+async function handleMarkAllAsRead() {
+  if (unreadCount.value === 0 || markAllLoading.value) return
+
+  markAllLoading.value = true
+  try {
+    await markAllAsRead()
+  } finally {
+    markAllLoading.value = false
+  }
 }
 </script>
 
@@ -73,10 +105,22 @@ function onInvitationResponded() {
 
     <template #content>
       <div class="max-h-80 overflow-y-auto">
-        <div class="border-b border-slate-200 px-4 py-3 dark:border-white/10">
+        <div
+          class="flex items-center justify-between border-b border-slate-200 px-4 py-3 dark:border-white/10"
+        >
           <h4 class="text-sm font-semibold text-slate-900 dark:text-white">
             {{ $t('notifications.title') }}
           </h4>
+          <UButton
+            size="xs"
+            color="neutral"
+            variant="ghost"
+            :loading="markAllLoading"
+            :disabled="unreadCount === 0 || markAllLoading"
+            @click="handleMarkAllAsRead"
+          >
+            {{ $t('notifications.markAllAsRead') }}
+          </UButton>
         </div>
 
         <div

--- a/app/composables/useNotifications.ts
+++ b/app/composables/useNotifications.ts
@@ -82,10 +82,16 @@ export function useNotifications() {
     refresh()
   }
 
+  async function markAllAsRead() {
+    await $fetch('/api/notifications/read-all', { method: 'PATCH' })
+    refresh()
+  }
+
   return {
     notifications,
     unreadCount,
     refresh,
-    markAsRead
+    markAsRead,
+    markAllAsRead
   }
 }

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -347,7 +347,9 @@
   "notifications": {
     "title": "Notifications",
     "noNotifications": "No notifications",
-    "viewInvitation": "Click to view invitation"
+    "viewInvitation": "Click to view invitation",
+    "markAllAsRead": "Mark all as read",
+    "issueUnavailable": "This issue is no longer available"
   },
   "invitation": {
     "title": "Project Invitation",

--- a/i18n/locales/zh-TW.json
+++ b/i18n/locales/zh-TW.json
@@ -347,7 +347,9 @@
   "notifications": {
     "title": "通知",
     "noNotifications": "暫無通知",
-    "viewInvitation": "點擊查看邀請"
+    "viewInvitation": "點擊查看邀請",
+    "markAllAsRead": "已讀全部通知",
+    "issueUnavailable": "此 Issue 已無法存取"
   },
   "invitation": {
     "title": "Project 邀請",

--- a/openspec/changes/archive/2026-04-04-notify-issue-status-navigate/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-04-notify-issue-status-navigate/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-04

--- a/openspec/changes/archive/2026-04-04-notify-issue-status-navigate/design.md
+++ b/openspec/changes/archive/2026-04-04-notify-issue-status-navigate/design.md
@@ -1,0 +1,72 @@
+## Context
+
+The notification system already supports two creation flows (comment → `issue_comment`, invitation → `project_invite`) and a frontend popover with Supabase Realtime push. The `notifications` table has an `issueId` FK to `issues` but no direct `projectId` column. The `NotificationBell.vue` click handler currently only opens a modal for `project_invite` type; issue-related notifications just get marked as read with no navigation.
+
+The notification center also only supports single-item read actions. There is no bulk action to clear unread notifications after users review a batch.
+
+Key existing patterns to follow:
+- `comments.post.ts` inserts a notification after the main operation, checking `issue.createdBy !== userId` before inserting.
+- `index.get.ts` already LEFT JOINs `projectInvitations` and `projects` to enrich notification data.
+- `[issueId].patch.ts` currently fetches the existing issue (for type checking) before updating, but only selects `issueType` — needs to also select `status` and `createdBy`.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Create `issue_update` notifications when an issue's status field changes (NOTIF-007)
+- Enable click-to-navigate for `issue_update` and `issue_comment` notifications (NOTIF-005)
+- Add bulk "mark all as read" action in NotificationBell with i18n labels
+- Follow existing notification patterns for consistency
+
+**Non-Goals:**
+- Notifications for non-status field changes
+- Notification preferences or subscription system
+- Batch/digest notifications
+- Schema migration (no new columns)
+
+## Decisions
+
+### 1. Status change detection: compare before/after in the existing PATCH handler
+
+The `[issueId].patch.ts` handler already queries the existing issue before updating (line 36-39, selecting `issueType`). Extend this SELECT to also fetch `status`, `createdBy`, `projectKey`, and `issueNumber`. After the update, compare `existing.status` vs `result.data.status` to detect a change.
+
+**Alternative considered:** Database trigger on the `issues` table. Rejected because it would add hidden complexity outside the application layer, be harder to test, and diverge from the existing pattern where `comments.post.ts` inserts notifications inline.
+
+### 2. projectId for navigation: LEFT JOIN `issues` in the notifications GET endpoint
+
+Add a LEFT JOIN on `issues` (via `notifications.issueId`) to fetch `issues.projectId`. This is returned as `issueProjectId` in the response — naming matches the existing `invitationProjectId` pattern.
+
+**Alternative considered:** Add a `projectId` column to `notifications` table. Rejected because it requires a migration, introduces data redundancy, and `issueId` already provides the relationship. The cascade delete on `issueId` ensures no orphaned references.
+
+### 3. Frontend navigation: markAsRead first, then navigateTo
+
+In `NotificationBell.vue`, when an `issue_update` or `issue_comment` notification is clicked:
+1. Call `markAsRead(notification.id)` (fire-and-forget, no await)
+2. Close popover
+3. Call `navigateTo(`/projects/${issueProjectId}/issues/${issueId}`)` 
+
+Mark-as-read happens before navigation so even if navigation fails, the notification is still marked read (per user's decision). The `markAsRead` call is already fire-and-forget in the existing code pattern.
+
+### 4. Notification content format
+
+Title: `Issue {KEY-NUM} status updated` (English, consistent with comment notification pattern)
+Content: `{oldStatus} → {newStatus}` (concise, shows the delta)
+
+Example: Title = `Issue CT-42 status updated`, Content = `Open → In Progress`
+
+### 5. Bulk read API and UI: dedicated endpoint + composable action
+
+Add a dedicated endpoint `PATCH /api/notifications/read-all` that updates all unread notifications for `event.context.userId` with one SQL update (`set isRead=true where user_id=:userId and is_read=false`). Return `updatedCount` for observability.
+
+Expose this endpoint via `useNotifications().markAllAsRead()` and wire it to a header action button in `NotificationBell.vue`. The button is:
+- disabled when `unreadCount === 0`
+- loading while request is in-flight
+- labeled via i18n key `notifications.markAllAsRead`
+
+This keeps behavior consistent with existing composable boundaries (`markAsRead`, `refresh`) and avoids embedding API details directly inside the component.
+
+## Risks / Trade-offs
+
+- **[JOIN performance]** → The LEFT JOIN on `issues` adds one more join to the notifications query (now 3 JOINs total). With a LIMIT 50 and index on `notifications.user_id`, this is negligible. If it becomes a concern later, adding a denormalized `projectId` column is straightforward.
+- **[Missing projectId on deleted issues]** → If an issue is deleted, cascade delete removes the notification too, so `issueProjectId` will never be null for existing notifications. No edge case handling needed.
+- **[No guard on navigation target]** → If user no longer has access to the project (e.g., removed from members after notification was created), they'll hit a 404 on the issue page. This is acceptable — the issue page already handles this case.
+- **[Bulk update scope safety]** → A broad update query could accidentally mark another user's notifications as read if scoping is wrong. Mitigation: strict `where user_id = event.context.userId` and no client-supplied user ID.

--- a/openspec/changes/archive/2026-04-04-notify-issue-status-navigate/proposal.md
+++ b/openspec/changes/archive/2026-04-04-notify-issue-status-navigate/proposal.md
@@ -1,0 +1,38 @@
+## Why
+
+NOTIF-005 and NOTIF-007 are the two remaining planned notification features in the PRD. NOTIF-007 closes the feedback loop for issue reporters — when someone changes the status of their reported bug, they should know about it without polling the dashboard. NOTIF-005 makes all issue-related notifications (both `issue_update` and `issue_comment`) actionable by navigating the user directly to the relevant issue page on click.
+
+Additionally, once notification volume grows, marking notifications one-by-one creates unnecessary friction. Users need a fast way to clear the unread badge after reviewing the notification list.
+
+## Non-goals
+
+- Notifications for non-status field changes (title, description, etc.) — defer until subscription/preference system exists.
+- Notification preferences or unsubscribe mechanism.
+- Notifying assignees (assignee feature does not exist yet).
+
+## What Changes
+
+- **Issue status change notification (NOTIF-007)**: When an issue's `status` field is updated via `PATCH /api/projects/:projectId/issues/:issueId`, the system creates a notification for the issue creator (`created_by`). Self-updates (updater === creator) are skipped.
+- **Notification click navigation (NOTIF-005)**: Clicking an `issue_update` or `issue_comment` notification marks it as read and navigates to `/projects/:projectId/issues/:issueId`. The notification API is extended to return `projectId` via a JOIN on the `issues` table (no schema change needed).
+- **Mark all notifications as read**: Add `PATCH /api/notifications/read-all` to mark all unread notifications for the current user as read. Add a NotificationBell header action with i18n label (`notifications.markAllAsRead`) to trigger this endpoint.
+
+## Capabilities
+
+### New Capabilities
+
+- `issue-status-notification`: Server-side logic to detect issue status changes and create notifications for the issue creator.
+- `notification-navigate`: Frontend click handler that navigates to the issue detail page for issue-related notification types.
+- `notification-mark-all-read`: Server and frontend flow for marking all unread notifications as read in one action.
+
+### Modified Capabilities
+
+_(none — no existing spec-level requirements are changing)_
+
+## Impact
+
+- **Server API**: `PATCH /api/projects/:projectId/issues/:issueId` gains notification insertion logic. `GET /api/notifications` adds a LEFT JOIN on `issues` to return `projectId`.
+- **Server API**: Add `PATCH /api/notifications/read-all` for bulk read updates (scoped by current user).
+- **Frontend**: `NotificationBell.vue` click handler updated to call `navigateTo()` for issue-related types, and adds a "mark all as read" action with loading/disabled states.
+- **Database**: No schema migration required — uses existing `notifications.issue_id` FK and JOINs `issues.project_id`.
+- **i18n**: Add `notifications.markAllAsRead` in `en` and `zh-TW` locale files.
+- **PRD**: `NOTIF-005` status changes from "後續擴充" to implemented. `NOTIF-007` status changes from `[Planned]` to implemented.

--- a/openspec/changes/archive/2026-04-04-notify-issue-status-navigate/specs/issue-status-notification/spec.md
+++ b/openspec/changes/archive/2026-04-04-notify-issue-status-navigate/specs/issue-status-notification/spec.md
@@ -1,0 +1,30 @@
+## ADDED Requirements
+
+### Requirement: Notify issue creator on status change
+
+When an issue's `status` field is updated via `PATCH /api/projects/:projectId/issues/:issueId`, the system SHALL create a notification record for the issue creator (`created_by`) with type `issue_update`. The notification SHALL include the issue's friendly ID in the title and the old-to-new status transition in the content.
+
+#### Scenario: Status changed by another user
+
+- **WHEN** user A updates issue CT-42 status from `Open` to `In Progress`, and issue CT-42 was created by user B
+- **THEN** a notification is created with:
+  - `userId` = user B's ID
+  - `issueId` = CT-42's ID
+  - `type` = `issue_update`
+  - `title` = `Issue CT-42 status updated`
+  - `content` = `Open → In Progress`
+
+#### Scenario: Status changed by the issue creator themselves
+
+- **WHEN** user A updates their own issue CT-42 status from `Open` to `Done`
+- **THEN** no notification is created (self-update is skipped)
+
+#### Scenario: Non-status fields updated
+
+- **WHEN** user A updates issue CT-42's `title` or `description` without changing `status`
+- **THEN** no notification is created (only status changes trigger notifications)
+
+#### Scenario: Status field included but value unchanged
+
+- **WHEN** user A sends a PATCH with `{ "status": "Open" }` and the issue's current status is already `Open`
+- **THEN** no notification is created (no actual change occurred)

--- a/openspec/changes/archive/2026-04-04-notify-issue-status-navigate/specs/notification-navigate/spec.md
+++ b/openspec/changes/archive/2026-04-04-notify-issue-status-navigate/specs/notification-navigate/spec.md
@@ -1,0 +1,83 @@
+## ADDED Requirements
+
+### Requirement: Notifications API returns projectId for issue-related notifications
+
+The `GET /api/notifications` endpoint SHALL return an `issueProjectId` field for notifications that have an `issueId`. This field SHALL be populated by LEFT JOINing the `issues` table on `notifications.issueId` to fetch `issues.projectId`.
+
+#### Scenario: Notification with issueId
+
+- **WHEN** the notifications list is fetched and a notification has `issueId` referencing an existing issue in project `abc-123`
+- **THEN** the notification object includes `issueProjectId: "abc-123"`
+
+#### Scenario: Notification without issueId
+
+- **WHEN** the notifications list is fetched and a notification has `issueId: null` (e.g., a `project_invite` notification)
+- **THEN** the notification object includes `issueProjectId: null`
+
+### Requirement: Click issue-related notification to navigate to issue page
+
+When a user clicks an `issue_update` or `issue_comment` notification in the NotificationBell popover, the system SHALL mark the notification as read and navigate to `/projects/:projectId/issues/:issueId` using the `issueProjectId` and `issueId` from the notification data.
+
+#### Scenario: Click issue_update notification
+
+- **WHEN** user clicks an unread `issue_update` notification with `issueProjectId: "abc-123"` and `issueId: 42`
+- **THEN** the notification is marked as read, the popover closes, and the user is navigated to `/projects/abc-123/issues/42`
+
+#### Scenario: Click issue_comment notification
+
+- **WHEN** user clicks an unread `issue_comment` notification with `issueProjectId: "abc-123"` and `issueId: 42`
+- **THEN** the notification is marked as read, the popover closes, and the user is navigated to `/projects/abc-123/issues/42`
+
+#### Scenario: Click already-read issue notification
+
+- **WHEN** user clicks an already-read `issue_update` notification
+- **THEN** markAsRead is not called again, but navigation still occurs
+
+#### Scenario: Notification missing issueProjectId
+
+- **WHEN** user clicks an `issue_update` notification where `issueProjectId` is null (edge case)
+- **THEN** the notification is marked as read but no navigation occurs
+
+### Requirement: Mark all unread notifications as read
+
+The system SHALL provide `PATCH /api/notifications/read-all` to mark all unread notifications as read for the authenticated user only.
+
+#### Scenario: User has unread notifications
+
+- **WHEN** authenticated user A calls `PATCH /api/notifications/read-all` and has 3 unread notifications
+- **THEN** exactly those 3 notifications belonging to user A are updated to `isRead: true`
+- **AND** the API response includes `updatedCount: 3`
+
+#### Scenario: User has no unread notifications
+
+- **WHEN** authenticated user A calls `PATCH /api/notifications/read-all` and has no unread notifications
+- **THEN** no rows are updated
+- **AND** the API response includes `updatedCount: 0`
+
+#### Scenario: Other users' notifications remain unchanged
+
+- **WHEN** authenticated user A calls `PATCH /api/notifications/read-all`
+- **THEN** notifications belonging to any other user B are not modified
+
+### Requirement: NotificationBell supports bulk read action with i18n
+
+The NotificationBell popover SHALL expose a "mark all as read" action that triggers bulk read behavior and uses locale-specific text via `notifications.markAllAsRead`.
+
+#### Scenario: Trigger bulk read from NotificationBell
+
+- **WHEN** user clicks the NotificationBell header action while `unreadCount > 0`
+- **THEN** the UI enters loading state
+- **AND** invokes bulk read action
+- **AND** refreshes notifications and unread count after completion
+
+#### Scenario: Disable action when no unread notifications
+
+- **WHEN** `unreadCount` is `0`
+- **THEN** the NotificationBell bulk read action is disabled
+
+#### Scenario: Locale-specific button label
+
+- **WHEN** app locale is `en`
+- **THEN** the action label is `Mark all as read`
+- **WHEN** app locale is `zh-TW`
+- **THEN** the action label is `已讀全部通知`

--- a/openspec/changes/archive/2026-04-04-notify-issue-status-navigate/tasks.md
+++ b/openspec/changes/archive/2026-04-04-notify-issue-status-navigate/tasks.md
@@ -1,0 +1,25 @@
+## 1. Issue Status Change Notification (Server)
+
+- [x] 1.1 Extend existing issue SELECT in `[issueId].patch.ts` to also fetch `status`, `createdBy`, `projectKey`, `issueNumber`
+- [x] 1.2 After update, compare `existing.status` vs `result.data.status` — if changed and updater !== `createdBy`, INSERT notification with type `issue_update`, title `Issue {KEY-NUM} status updated`, content `{oldStatus} → {newStatus}`
+
+## 2. Notifications API: Return projectId via JOIN (Server)
+
+- [x] 2.1 In `notifications/index.get.ts`, add LEFT JOIN on `issues` table via `notifications.issueId` and include `issues.projectId` as `issueProjectId` in the select
+
+## 3. Notification Click Navigation (Frontend)
+
+- [x] 3.1 Update `NotificationBell.vue` click handler: for `issue_update` and `issue_comment` types with `issueProjectId` and `issueId`, call `markAsRead` (if unread), close popover, then `navigateTo(/projects/:projectId/issues/:issueId)`
+- [x] 3.2 Guard against missing `issueProjectId`: if null, mark as read but skip navigation
+
+## 4. Verification
+
+- [x] 4.1 Run `pnpm lint` and `pnpm typecheck` to verify no regressions
+
+## 5. Mark All Notifications As Read
+
+- [x] 5.1 Add `PATCH /api/notifications/read-all` endpoint to update unread notifications for current user and return `updatedCount`
+- [x] 5.2 Extend `useNotifications` with `markAllAsRead()` and refresh notification data after success
+- [x] 5.3 Add NotificationBell header action button to trigger bulk read with loading and disabled states
+- [x] 5.4 Add i18n key `notifications.markAllAsRead` in `i18n/locales/en.json` and `i18n/locales/zh-TW.json`
+- [x] 5.5 Re-run `pnpm lint` and `pnpm typecheck` after bulk-read changes

--- a/openspec/specs/issue-status-notification/spec.md
+++ b/openspec/specs/issue-status-notification/spec.md
@@ -1,0 +1,34 @@
+# issue-status-notification Specification
+
+## Purpose
+TBD - created by archiving change notify-issue-status-navigate. Update Purpose after archive.
+## Requirements
+### Requirement: Notify issue creator on status change
+
+When an issue's `status` field is updated via `PATCH /api/projects/:projectId/issues/:issueId`, the system SHALL create a notification record for the issue creator (`created_by`) with type `issue_update`. The notification SHALL include the issue's friendly ID in the title and the old-to-new status transition in the content.
+
+#### Scenario: Status changed by another user
+
+- **WHEN** user A updates issue CT-42 status from `Open` to `In Progress`, and issue CT-42 was created by user B
+- **THEN** a notification is created with:
+  - `userId` = user B's ID
+  - `issueId` = CT-42's ID
+  - `type` = `issue_update`
+  - `title` = `Issue CT-42 status updated`
+  - `content` = `Open → In Progress`
+
+#### Scenario: Status changed by the issue creator themselves
+
+- **WHEN** user A updates their own issue CT-42 status from `Open` to `Done`
+- **THEN** no notification is created (self-update is skipped)
+
+#### Scenario: Non-status fields updated
+
+- **WHEN** user A updates issue CT-42's `title` or `description` without changing `status`
+- **THEN** no notification is created (only status changes trigger notifications)
+
+#### Scenario: Status field included but value unchanged
+
+- **WHEN** user A sends a PATCH with `{ "status": "Open" }` and the issue's current status is already `Open`
+- **THEN** no notification is created (no actual change occurred)
+

--- a/openspec/specs/notification-navigate/spec.md
+++ b/openspec/specs/notification-navigate/spec.md
@@ -1,0 +1,87 @@
+# notification-navigate Specification
+
+## Purpose
+TBD - created by archiving change notify-issue-status-navigate. Update Purpose after archive.
+## Requirements
+### Requirement: Notifications API returns projectId for issue-related notifications
+
+The `GET /api/notifications` endpoint SHALL return an `issueProjectId` field for notifications that have an `issueId`. This field SHALL be populated by LEFT JOINing the `issues` table on `notifications.issueId` to fetch `issues.projectId`.
+
+#### Scenario: Notification with issueId
+
+- **WHEN** the notifications list is fetched and a notification has `issueId` referencing an existing issue in project `abc-123`
+- **THEN** the notification object includes `issueProjectId: "abc-123"`
+
+#### Scenario: Notification without issueId
+
+- **WHEN** the notifications list is fetched and a notification has `issueId: null` (e.g., a `project_invite` notification)
+- **THEN** the notification object includes `issueProjectId: null`
+
+### Requirement: Click issue-related notification to navigate to issue page
+
+When a user clicks an `issue_update` or `issue_comment` notification in the NotificationBell popover, the system SHALL mark the notification as read and navigate to `/projects/:projectId/issues/:issueId` using the `issueProjectId` and `issueId` from the notification data.
+
+#### Scenario: Click issue_update notification
+
+- **WHEN** user clicks an unread `issue_update` notification with `issueProjectId: "abc-123"` and `issueId: 42`
+- **THEN** the notification is marked as read, the popover closes, and the user is navigated to `/projects/abc-123/issues/42`
+
+#### Scenario: Click issue_comment notification
+
+- **WHEN** user clicks an unread `issue_comment` notification with `issueProjectId: "abc-123"` and `issueId: 42`
+- **THEN** the notification is marked as read, the popover closes, and the user is navigated to `/projects/abc-123/issues/42`
+
+#### Scenario: Click already-read issue notification
+
+- **WHEN** user clicks an already-read `issue_update` notification
+- **THEN** markAsRead is not called again, but navigation still occurs
+
+#### Scenario: Notification missing issueProjectId
+
+- **WHEN** user clicks an `issue_update` notification where `issueProjectId` is null (edge case)
+- **THEN** the notification is marked as read but no navigation occurs
+
+### Requirement: Mark all unread notifications as read
+
+The system SHALL provide `PATCH /api/notifications/read-all` to mark all unread notifications as read for the authenticated user only.
+
+#### Scenario: User has unread notifications
+
+- **WHEN** authenticated user A calls `PATCH /api/notifications/read-all` and has 3 unread notifications
+- **THEN** exactly those 3 notifications belonging to user A are updated to `isRead: true`
+- **AND** the API response includes `updatedCount: 3`
+
+#### Scenario: User has no unread notifications
+
+- **WHEN** authenticated user A calls `PATCH /api/notifications/read-all` and has no unread notifications
+- **THEN** no rows are updated
+- **AND** the API response includes `updatedCount: 0`
+
+#### Scenario: Other users' notifications remain unchanged
+
+- **WHEN** authenticated user A calls `PATCH /api/notifications/read-all`
+- **THEN** notifications belonging to any other user B are not modified
+
+### Requirement: NotificationBell supports bulk read action with i18n
+
+The NotificationBell popover SHALL expose a "mark all as read" action that triggers bulk read behavior and uses locale-specific text via `notifications.markAllAsRead`.
+
+#### Scenario: Trigger bulk read from NotificationBell
+
+- **WHEN** user clicks the NotificationBell header action while `unreadCount > 0`
+- **THEN** the UI enters loading state
+- **AND** invokes bulk read action
+- **AND** refreshes notifications and unread count after completion
+
+#### Scenario: Disable action when no unread notifications
+
+- **WHEN** `unreadCount` is `0`
+- **THEN** the NotificationBell bulk read action is disabled
+
+#### Scenario: Locale-specific button label
+
+- **WHEN** app locale is `en`
+- **THEN** the action label is `Mark all as read`
+- **WHEN** app locale is `zh-TW`
+- **THEN** the action label is `已讀全部通知`
+

--- a/server/api/notifications/index.get.ts
+++ b/server/api/notifications/index.get.ts
@@ -1,5 +1,11 @@
 import { eq, desc, and, lt, isNotNull } from 'drizzle-orm'
-import { notifications, projectInvitations, projects, profiles, issues } from '~~/server/database/schema'
+import {
+  notifications,
+  projectInvitations,
+  projects,
+  profiles,
+  issues
+} from '~~/server/database/schema'
 import { InvitationStatus } from '~~/shared/constants'
 
 export default defineEventHandler(async (event) => {

--- a/server/api/notifications/index.get.ts
+++ b/server/api/notifications/index.get.ts
@@ -1,5 +1,5 @@
 import { eq, desc, and, lt, isNotNull } from 'drizzle-orm'
-import { notifications, projectInvitations, projects, profiles } from '~~/server/database/schema'
+import { notifications, projectInvitations, projects, profiles, issues } from '~~/server/database/schema'
 import { InvitationStatus } from '~~/shared/constants'
 
 export default defineEventHandler(async (event) => {
@@ -35,6 +35,7 @@ export default defineEventHandler(async (event) => {
       content: notifications.content,
       isRead: notifications.isRead,
       issueId: notifications.issueId,
+      issueProjectId: issues.projectId,
       projectInvitationId: notifications.projectInvitationId,
       createdAt: notifications.createdAt,
       // project invitation join fields
@@ -43,6 +44,7 @@ export default defineEventHandler(async (event) => {
       projectName: projects.name
     })
     .from(notifications)
+    .leftJoin(issues, eq(notifications.issueId, issues.id))
     .leftJoin(projectInvitations, eq(notifications.projectInvitationId, projectInvitations.id))
     .leftJoin(projects, eq(projectInvitations.projectId, projects.id))
     .where(eq(notifications.userId, userId))

--- a/server/api/notifications/read-all.patch.ts
+++ b/server/api/notifications/read-all.patch.ts
@@ -1,0 +1,19 @@
+import { and, eq } from 'drizzle-orm'
+import { notifications } from '~~/server/database/schema'
+
+export default defineEventHandler(async (event) => {
+  const db = useDB()
+  const userId = event.context.userId as string
+
+  const updated = await db
+    .update(notifications)
+    .set({ isRead: true })
+    .where(and(eq(notifications.userId, userId), eq(notifications.isRead, false)))
+    .returning({ id: notifications.id })
+
+  return {
+    data: {
+      updatedCount: updated.length
+    }
+  }
+})

--- a/server/api/projects/[projectId]/issues/[issueId].patch.ts
+++ b/server/api/projects/[projectId]/issues/[issueId].patch.ts
@@ -1,7 +1,7 @@
 import { and, eq } from 'drizzle-orm'
-import { issues } from '~~/server/database/schema'
+import { issues, notifications } from '~~/server/database/schema'
 import { updateIssueSchema, API_BUG_ONLY_FIELDS } from '~~/shared/schemas'
-import { IssueType } from '~~/shared/constants'
+import { IssueType, NotificationType } from '~~/shared/constants'
 import { badRequest, notFound } from '~~/server/utils/errors'
 import { getAccessibleProject } from '~~/server/utils/project-access'
 
@@ -32,36 +32,62 @@ export default defineEventHandler(async (event) => {
     badRequest('No fields to update')
   }
 
-  // Fetch existing issue to check type
-  const [existing] = await db
-    .select({ issueType: issues.issueType })
-    .from(issues)
-    .where(and(eq(issues.id, Number(issueId)), eq(issues.projectId, projectId)))
+  const updatedIssue = await db.transaction(async (tx) => {
+    // Lock issue row to avoid race conditions between read/check and update.
+    const [existing] = await tx
+      .select({
+        issueType: issues.issueType,
+        status: issues.status,
+        createdBy: issues.createdBy,
+        projectKey: issues.projectKey,
+        issueNumber: issues.issueNumber
+      })
+      .from(issues)
+      .where(and(eq(issues.id, Number(issueId)), eq(issues.projectId, projectId)))
+      .for('update')
 
-  if (!existing) {
-    notFound('Issue not found')
-  }
-
-  // Reject API-only fields for task type
-  if (existing.issueType === IssueType.Task) {
-    const invalidFields = API_BUG_ONLY_FIELDS.filter((f) => result.data[f] !== undefined)
-    if (invalidFields.length > 0) {
-      badRequest(`Cannot set API fields on a Task issue: ${invalidFields.join(', ')}`)
+    if (!existing) {
+      notFound('Issue not found')
     }
-  }
 
-  const [updatedIssue] = await db
-    .update(issues)
-    .set({
-      ...result.data,
-      updatedAt: new Date()
-    })
-    .where(and(eq(issues.id, Number(issueId)), eq(issues.projectId, projectId)))
-    .returning()
+    // Reject API-only fields for task type
+    if (existing.issueType === IssueType.Task) {
+      const invalidFields = API_BUG_ONLY_FIELDS.filter((f) => result.data[f] !== undefined)
+      if (invalidFields.length > 0) {
+        badRequest(`Cannot set API fields on a Task issue: ${invalidFields.join(', ')}`)
+      }
+    }
 
-  if (!updatedIssue) {
-    notFound('Issue not found')
-  }
+    const [updated] = await tx
+      .update(issues)
+      .set({
+        ...result.data,
+        updatedAt: new Date()
+      })
+      .where(and(eq(issues.id, Number(issueId)), eq(issues.projectId, projectId)))
+      .returning()
+
+    if (!updated) {
+      notFound('Issue not found')
+    }
+
+    if (
+      result.data.status !== undefined &&
+      existing.status !== updated.status &&
+      existing.createdBy &&
+      existing.createdBy !== userId
+    ) {
+      await tx.insert(notifications).values({
+        userId: existing.createdBy,
+        issueId: updated.id,
+        type: NotificationType.IssueUpdate,
+        title: `Issue ${existing.projectKey}-${existing.issueNumber} status updated`,
+        content: `${existing.status} → ${updated.status}`
+      })
+    }
+
+    return updated
+  })
 
   return {
     data: updatedIssue,

--- a/server/database/schema/notifications.ts
+++ b/server/database/schema/notifications.ts
@@ -1,13 +1,14 @@
 import { pgTable, uuid, varchar, timestamp, boolean, integer } from 'drizzle-orm/pg-core'
 import { issues } from './issues'
 import { projectInvitations } from './project-invitations'
+import type { NotificationType } from '~~/shared/constants'
 
 export const notifications = pgTable('notifications', {
   id: uuid('id').primaryKey().defaultRandom(),
   userId: uuid('user_id').notNull(), // FK to auth.users (接收通知的人)
   issueId: integer('issue_id').references(() => issues.id, { onDelete: 'cascade' }),
 
-  type: varchar('type', { length: 30 }).notNull().default('issue_update'),
+  type: varchar('type', { length: 30 }).notNull().$type<NotificationType>().default('issue_update'),
   projectInvitationId: uuid('project_invitation_id').references(() => projectInvitations.id, {
     onDelete: 'cascade'
   }),

--- a/server/database/schema/project-invitations.ts
+++ b/server/database/schema/project-invitations.ts
@@ -15,7 +15,10 @@ export const projectInvitations = pgTable(
       .references(() => projects.id, { onDelete: 'cascade' }),
     email: varchar('email', { length: 255 }).notNull(),
     invitedBy: uuid('invited_by').notNull(),
-    status: varchar('status', { length: 20 }).notNull().$type<InvitationStatus>().default(InvitationStatus.Pending),
+    status: varchar('status', { length: 20 })
+      .notNull()
+      .$type<InvitationStatus>()
+      .default(InvitationStatus.Pending),
     expiresAt: timestamp('expires_at', { withTimezone: true }),
     createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
     acceptedAt: timestamp('accepted_at', { withTimezone: true })

--- a/server/database/schema/project-invitations.ts
+++ b/server/database/schema/project-invitations.ts
@@ -15,7 +15,7 @@ export const projectInvitations = pgTable(
       .references(() => projects.id, { onDelete: 'cascade' }),
     email: varchar('email', { length: 255 }).notNull(),
     invitedBy: uuid('invited_by').notNull(),
-    status: varchar('status', { length: 20 }).notNull().default(InvitationStatus.Pending),
+    status: varchar('status', { length: 20 }).notNull().$type<InvitationStatus>().default(InvitationStatus.Pending),
     expiresAt: timestamp('expires_at', { withTimezone: true }),
     createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
     acceptedAt: timestamp('accepted_at', { withTimezone: true })

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -1,1 +1,2 @@
 export * from './pagination'
+export * from './notification'

--- a/shared/types/notification.ts
+++ b/shared/types/notification.ts
@@ -1,0 +1,16 @@
+import type { InvitationStatus, NotificationType } from '../constants'
+
+export interface NotificationItem {
+  id: string
+  type: NotificationType
+  title: string
+  content: string | null
+  isRead: boolean
+  issueId: number | null
+  issueProjectId: string | null
+  projectInvitationId: string | null
+  createdAt: string
+  invitationProjectId: string | null
+  invitationStatus: InvitationStatus | null
+  projectName: string | null
+}


### PR DESCRIPTION
## Summary

- Clicking an issue update/comment notification now navigates directly to the issue detail page, closing the popover and marking the notification as read in one action
- Adds a "Mark All as Read" button in the notification panel to bulk-clear unread state in a single API call
- Introduces a shared `NotificationItem` type and refactors notification click handling into focused per-type handlers for clarity

## Type of Change

- [x] feat: new feature
- [ ] fix: bug fix
- [ ] refactor: code restructuring (no behavior change)
- [ ] chore: maintenance, CI, deps
- [ ] docs: documentation only

## Related Issues

<!-- Link related issues: closes #123, fixes #456 -->

## Test Plan

- [x] Tested locally
- [x] Lint passes (`pnpm lint`)
- [x] Typecheck passes (`pnpm typecheck`)

## Screenshots

<!-- If UI changes, add before/after screenshots. Remove this section if not applicable. -->