### PR TITLE
feat(comments): display Google avatar in comment composer

### DIFF
--- a/app/components/IssueComments.vue
+++ b/app/components/IssueComments.vue
@@ -122,7 +122,7 @@ const currentUserAvatarColor = computed(() => {
           :alt="currentUserInitials"
           class="size-10 shrink-0 rounded-full object-cover"
           referrerpolicy="no-referrer"
-        >
+        />
         <div
           v-else
           class="flex size-10 shrink-0 items-center justify-center rounded-full text-xs font-semibold"
@@ -131,9 +131,7 @@ const currentUserAvatarColor = computed(() => {
           {{ currentUserInitials }}
         </div>
         <template #fallback>
-          <div
-            class="size-10 shrink-0 rounded-full bg-slate-100 dark:bg-slate-800"
-          />
+          <div class="size-10 shrink-0 rounded-full bg-slate-100 dark:bg-slate-800" />
         </template>
       </ClientOnly>
 

--- a/app/components/IssueComments.vue
+++ b/app/components/IssueComments.vue
@@ -42,6 +42,8 @@ function isOwnComment(authorId: string) {
   return profile.value?.id === authorId
 }
 
+const currentUserAvatarUrl = computed(() => profile.value?.avatarUrl ?? null)
+
 const currentUserInitials = computed(() => {
   const p = profile.value
   if (!p) return '?'
@@ -113,12 +115,27 @@ const currentUserAvatarColor = computed(() => {
     <!-- Composer -->
     <div class="flex items-start gap-4">
       <!-- Current user avatar -->
-      <div
-        class="flex size-10 shrink-0 items-center justify-center rounded-full text-xs font-semibold"
-        :class="currentUserAvatarColor"
-      >
-        {{ currentUserInitials }}
-      </div>
+      <ClientOnly>
+        <img
+          v-if="currentUserAvatarUrl"
+          :src="currentUserAvatarUrl"
+          :alt="currentUserInitials"
+          class="size-10 shrink-0 rounded-full object-cover"
+          referrerpolicy="no-referrer"
+        >
+        <div
+          v-else
+          class="flex size-10 shrink-0 items-center justify-center rounded-full text-xs font-semibold"
+          :class="currentUserAvatarColor"
+        >
+          {{ currentUserInitials }}
+        </div>
+        <template #fallback>
+          <div
+            class="size-10 shrink-0 rounded-full bg-slate-100 dark:bg-slate-800"
+          />
+        </template>
+      </ClientOnly>
 
       <!-- Editor Card -->
       <div

--- a/app/composables/useProfile.ts
+++ b/app/composables/useProfile.ts
@@ -6,6 +6,7 @@ type Profile = {
   name: string | null
   role: string
   createdAt: string
+  avatarUrl: string | null
 }
 
 type ProfileState = {

--- a/server/api/auth/me.get.ts
+++ b/server/api/auth/me.get.ts
@@ -7,6 +7,12 @@ import { getProfile } from '~~/server/utils/profile'
 export default defineEventHandler(async (event) => {
   const db = useDB()
   const userId = event.context.userId as string
+  const profile = await getProfile(db, userId)
 
-  return await getProfile(db, userId)
+  if (!profile) return null
+
+  const metadata = event.context.userMetadata as Record<string, unknown> | undefined
+  const avatarUrl = (metadata?.avatar_url ?? metadata?.picture ?? null) as string | null
+
+  return { ...profile, avatarUrl }
 })


### PR DESCRIPTION
## Summary

- Show the user's Google profile picture in the comment composer instead of just initials
- Extract `avatar_url` from Supabase auth metadata in the `/api/auth/me` endpoint and expose it to the client
- Gracefully fall back to initials avatar when no Google avatar is available, with a skeleton placeholder during SSR

## Type of Change

- [x] feat: new feature
- [ ] fix: bug fix
- [ ] refactor: code restructuring (no behavior change)
- [ ] chore: maintenance, CI, deps
- [ ] docs: documentation only

## Related Issues

## Test Plan

- [ ] Tested locally
- [ ] Lint passes (`pnpm lint`)
- [ ] Typecheck passes (`pnpm typecheck`)