### PR TITLE
feat(cli): add create-issue command

### DIFF
--- a/openspec/changes/archive/2026-04-10-cli-create-issue/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-10-cli-create-issue/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-09

--- a/openspec/changes/archive/2026-04-10-cli-create-issue/design.md
+++ b/openspec/changes/archive/2026-04-10-cli-create-issue/design.md
@@ -1,0 +1,126 @@
+## Context
+
+The CLI (`packages/cli/`) is a standalone npm package built with Commander.js. It currently supports read, update-status, and delete operations on issues, but has no create-issue command. The web UI creates issues via `POST /api/projects/:projectId/issues` (with cURL parsing via `POST /api/curl/parse`). Both server endpoints already exist and need no modification — the CLI will be a new consumer.
+
+Existing CLI patterns:
+- Each command is a standalone function in `src/commands/<name>.ts`, taking `(client, ...args, json)` as parameters
+- Commands are registered in `src/index.ts` with Commander.js, wrapped by `withAuth()` and `handleError()`
+- Interactive prompts use Node.js `readline` (see `confirm()` in `utils.ts`)
+- API calls go through `CurlTicketClient` methods in `api-client.ts`
+- Output follows a dual mode: human-readable (default) or `--json` raw output
+
+## Goals / Non-Goals
+
+**Goals:**
+- Add `ct create-issue <projectId>` command with `--type api_bug|task`
+- API Bug mode: accept `--curl "..."`, parse it server-side, create the issue with parsed data
+- Task mode: interactive guided flow (title → gate → optional details → preview → confirm)
+- Non-interactive mode: `--title "..." [--description "..."]` for scripting/CI
+- Consistent `--json` output matching other commands
+- Proper validation and error handling following existing patterns
+
+**Non-Goals:**
+- No editing of parsed cURL fields before issue creation
+- No file upload or multi-part body support
+- No environment auto-detection (explicit `--env` flag)
+- No new npm dependencies
+
+## Decisions
+
+### 1. Command signature design
+
+```
+ct create-issue <projectId> [--type <api_bug|task>] [options]
+```
+
+**Rationale:** Follows existing patterns (`ct delete-issue <projectId> <issueId>`). `projectId` is a positional argument because it's always required. `--type` is optional — when omitted in an interactive terminal, the CLI prompts the user to select between `API Bug` and `Task` via a numbered menu. This keeps the interactive experience smooth (no need to remember flags) while still supporting explicit `--type` for scripting.
+
+**Alternatives considered:**
+- Subcommands (`ct create-issue api-bug <projectId>`) — rejected because it diverges from the flat option pattern used by `--status` and `--type` in `issues` command
+- `--type` always required — rejected because interactive selection provides a better UX for terminal users; non-interactive mode still requires explicit `--type`
+
+### 2. API Bug flow: parse then create (two API calls)
+
+For `--type api_bug --curl "..."`:
+1. Call `POST /api/curl/parse` with the raw cURL string → receive `{ url, method, headers, body }`
+2. Call `POST /api/projects/:projectId/issues` with the parsed data + auto-generated title
+
+**Rationale:** Reuses the existing server-side parsing. The server already uses `curlconverter` which handles edge cases (quoted strings, escaped chars, multi-line). No need to replicate this logic in the CLI.
+
+**Auto-generated title:** `<METHOD> <url_path>` (e.g., `POST /api/users`). User can override with `--title`.
+
+### 3. Task flow: gated interactive prompts using readline
+
+Follows the `gh issue create` style gate pattern:
+
+```
+Title: _______________
+What's next?
+  > Create now
+    Add details
+    Cancel
+```
+
+If "Add details" is selected:
+```
+Why (motivation): _______________
+Goal (expected outcome): _______________
+```
+
+Then compose a Markdown description:
+```markdown
+## Why
+<user input>
+
+## Goal
+<user input>
+```
+
+Preview the composed issue, then confirm creation.
+
+**Rationale:** Uses Node.js built-in `readline` (already a dependency pattern in `utils.ts`). No need for `inquirer` or `prompts` — keeps the CLI dependency-free. The gate pattern prevents unnecessary prompts while still offering detail for those who want it.
+
+**Implementation:** Create a `promptInput(question)` helper alongside the existing `confirm()` in utils, and a `promptSelect(question, choices)` for the gate menu.
+
+### 4. Non-interactive mode detection
+
+If `--title` is provided (and `--type` for task), skip all interactive prompts. For API Bug + `--curl`, auto-generate title from parsed data unless `--title` is explicitly provided.
+
+If stdin is not a TTY (piped input), also skip interactive prompts — fail with a clear error if required info is missing (`--type` and `--title`).
+
+**Rationale:** Enables scripting: `ct create-issue $PID --type task --title "Fix login bug"`. TTY detection prevents hangs in CI pipelines.
+
+### 5. File structure
+
+```
+packages/cli/src/
+  commands/
+    create-issue.ts       # Command handler (orchestrates flow)
+  api-client.ts           # Add parseCurl() and createIssue() methods
+  types.ts                # Add CreateIssueInput, ParseCurlResponse types
+  utils.ts                # Add promptInput(), promptSelect() helpers
+```
+
+Single command file, not split by type — the branching logic is straightforward enough to keep in one file.
+
+### 6. CLI option mapping
+
+| Flag | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `<projectId>` | positional | yes | — | Target project UUID |
+| `--type <type>` | option | no (prompted if omitted) | — | `api_bug` or `task` |
+| `--curl <curl>` | option | api_bug only | — | Raw cURL command string |
+| `--title <title>` | option | no | auto-gen for api_bug | Issue title |
+| `--description <desc>` | option | no | — | Issue description (Markdown) |
+| `--env <env>` | option | no | `Dev` | Environment (api_bug only) |
+| `--status <status>` | option | no | `Open` | Initial issue status |
+
+## Risks / Trade-offs
+
+**[Risk] Long cURL strings may cause shell quoting issues** → Users should wrap cURL in single quotes. Document this in the command help text. The CLI receives the already-parsed shell argument, so double-quoting within the cURL is preserved.
+
+**[Risk] Interactive prompts block in non-TTY environments** → Mitigated by TTY detection: if `!process.stdin.isTTY` and required input is missing, exit with a clear error message instead of hanging.
+
+**[Risk] Large request/response bodies in cURL** → No CLI-side size limit; the server API handles validation. The CLI just forwards the parsed data.
+
+**[Trade-off] No pre-creation field editing for API Bug** → Keeps the flow simple (parse → create). Users who need to modify fields can use the web UI after creation. The printed result includes the issue URL/ID for quick access.

--- a/openspec/changes/archive/2026-04-10-cli-create-issue/proposal.md
+++ b/openspec/changes/archive/2026-04-10-cli-create-issue/proposal.md
@@ -1,0 +1,36 @@
+## Why
+
+The CLI (`ct`) currently supports listing, viewing, updating status, and deleting issues, but cannot **create** them. Users must switch to the web UI to file new issues, breaking their terminal workflow. Adding `ct create-issue` closes this gap and is especially valuable for API Bug issues — engineers can pipe a cURL command directly from their terminal into a new issue without context-switching.
+
+## What Changes
+
+- **New `create-issue` command** with two modes based on issue type:
+  - `--type api_bug --curl "..."` — parses the cURL via `POST /api/curl/parse`, then creates the issue with the parsed request data
+  - `--type task` — interactive guided flow (gh issue create style): prompt for title → gate ("Create now / Add details / Cancel") → optional Why + Goal → preview → confirm
+- **Non-interactive mode** for CI/scripting: `--title "..." [--description "..."]` bypasses all prompts
+- **New API client methods** on `CurlTicketClient`: `parseCurl(curl)` and `createIssue(projectId, data)`
+- **JSON output support** (`--json`) consistent with other commands
+
+## Non-goals
+
+- No file-upload or multi-part body support for cURL parsing
+- No editing of parsed cURL fields before creation (user can update after creation via web UI)
+- No environment auto-detection — user must pass `--env` explicitly for API Bug issues
+- No SDD (Spec-Driven Development) integration — the command creates concise issues; detailed specs remain a developer choice outside the CLI
+
+## Capabilities
+
+### New Capabilities
+
+- `cli-create-issue`: Covers the `ct create-issue` command, including API Bug mode (cURL parsing + creation), Task mode (interactive guided flow), non-interactive mode, argument validation, and JSON output.
+
+### Modified Capabilities
+
+_(none — no existing spec-level requirements change)_
+
+## Impact
+
+- **CLI package** (`packages/cli/`): new command file, updated `index.ts` registration, new API client methods, new types for create-issue input/response and cURL parse response
+- **Server APIs used**: `POST /api/curl/parse` (existing), `POST /api/projects/:projectId/issues` (existing) — no server changes needed
+- **Dependencies**: no new npm dependencies — interactive prompts use Node.js built-in `readline` (already used by `confirm()` in `utils.ts`)
+- **Shared schemas**: `createIssueSchema` from `shared/schemas/issue.ts` informs the CLI input shape, but validation runs server-side; CLI does lightweight pre-validation

--- a/openspec/changes/archive/2026-04-10-cli-create-issue/specs/cli-create-issue/spec.md
+++ b/openspec/changes/archive/2026-04-10-cli-create-issue/specs/cli-create-issue/spec.md
@@ -1,0 +1,130 @@
+## ADDED Requirements
+
+### Requirement: Interactive issue type selection
+The CLI SHALL prompt the user to select between `API Bug` and `Task` when `--type` is not provided and stdin is a TTY.
+
+#### Scenario: No --type flag in interactive terminal
+- **WHEN** user runs `ct create-issue <projectId>` without `--type` in an interactive terminal
+- **THEN** the CLI presents a numbered menu: `1) API Bug  2) Task`
+- **WHEN** user selects `1`
+- **THEN** the CLI proceeds with the API Bug flow
+
+#### Scenario: No --type flag in interactive terminal — select Task
+- **WHEN** user runs `ct create-issue <projectId>` without `--type` in an interactive terminal
+- **THEN** the CLI presents a numbered menu: `1) API Bug  2) Task`
+- **WHEN** user selects `2`
+- **THEN** the CLI proceeds with the Task flow
+
+#### Scenario: No --type in non-TTY environment
+- **WHEN** the command runs in a non-TTY environment without `--type`
+- **THEN** the CLI SHALL exit with an error: `--type is required in non-interactive mode`
+
+#### Scenario: Explicit --type flag skips prompt
+- **WHEN** user runs `ct create-issue <projectId> --type task`
+- **THEN** the CLI skips the type selection prompt and proceeds directly with the Task flow
+
+### Requirement: Create API Bug issue from cURL command
+The CLI SHALL support creating an API Bug issue by accepting a raw cURL command string, parsing it server-side, and submitting the parsed data to create the issue.
+
+#### Scenario: Create API Bug with --curl flag
+- **WHEN** user runs `ct create-issue <projectId> --type api_bug --curl "curl -X POST https://api.example.com/users -H 'Content-Type: application/json' -d '{"name":"test"}'"`
+- **THEN** the CLI calls `POST /api/curl/parse` with the cURL string, receives parsed `{ url, method, headers, body }`, generates a title as `POST /users`, and calls `POST /api/projects/:projectId/issues` with `issueType: "api_bug"` and the parsed data
+- **THEN** the CLI prints the created issue's friendly ID (e.g., `CT-42`) and title
+
+#### Scenario: Create API Bug with --curl and explicit --title
+- **WHEN** user runs `ct create-issue <projectId> --type api_bug --curl "..." --title "Login 500 error"`
+- **THEN** the CLI uses the provided title instead of auto-generating one from the parsed URL
+
+#### Scenario: Create API Bug with --curl and --env
+- **WHEN** user runs `ct create-issue <projectId> --type api_bug --curl "..." --env Prod`
+- **THEN** the created issue has `environment` set to `Prod`
+
+#### Scenario: Create API Bug without --curl flag
+- **WHEN** user runs `ct create-issue <projectId> --type api_bug` without `--curl`
+- **THEN** the CLI SHALL exit with a validation error: `--curl is required for api_bug type`
+
+### Requirement: Create Task issue with interactive guided flow
+The CLI SHALL support creating a Task issue through an interactive guided flow when no `--title` flag is provided and stdin is a TTY.
+
+#### Scenario: Interactive task — create now (minimal)
+- **WHEN** user runs `ct create-issue <projectId> --type task` in an interactive terminal
+- **THEN** the CLI prompts for `Title` (required)
+- **THEN** the CLI presents a gate menu: `Create now` / `Add details` / `Cancel`
+- **WHEN** user selects `Create now`
+- **THEN** the CLI creates the issue with only the title and prints the created issue
+
+#### Scenario: Interactive task — add details
+- **WHEN** user selects `Add details` at the gate menu
+- **THEN** the CLI prompts for `Why (motivation)` and `Goal (expected outcome)`
+- **THEN** the CLI composes a Markdown description with `## Why` and `## Goal` sections
+- **THEN** the CLI shows a preview of the issue (title + description) and asks for confirmation
+- **WHEN** user confirms
+- **THEN** the CLI creates the issue and prints the created issue
+
+#### Scenario: Interactive task — cancel
+- **WHEN** user selects `Cancel` at the gate menu
+- **THEN** the CLI prints `Cancelled.` and exits without creating an issue
+
+#### Scenario: Interactive task — empty title
+- **WHEN** user enters an empty string for the title prompt
+- **THEN** the CLI SHALL re-prompt for the title (title is required)
+
+### Requirement: Non-interactive mode for scripting
+The CLI SHALL support a non-interactive mode that bypasses all prompts when `--title` is provided, enabling use in scripts and CI pipelines.
+
+#### Scenario: Non-interactive task creation
+- **WHEN** user runs `ct create-issue <projectId> --type task --title "Refactor auth module" --description "Clean up the middleware"`
+- **THEN** the CLI creates the issue directly without any prompts
+
+#### Scenario: Non-interactive task with title only
+- **WHEN** user runs `ct create-issue <projectId> --type task --title "Fix bug"`
+- **THEN** the CLI creates the issue with null description, no prompts
+
+#### Scenario: Non-TTY without --title for task type
+- **WHEN** the command runs in a non-TTY environment (e.g., piped input) without `--title` for task type
+- **THEN** the CLI SHALL exit with an error: `--title is required in non-interactive mode`
+
+#### Scenario: Non-TTY without --type
+- **WHEN** the command runs in a non-TTY environment without `--type`
+- **THEN** the CLI SHALL exit with an error: `--type is required in non-interactive mode`
+
+### Requirement: JSON output mode
+The CLI SHALL support `--json` flag to output raw JSON responses, consistent with other commands.
+
+#### Scenario: Create issue with --json
+- **WHEN** user runs `ct create-issue <projectId> --type task --title "Test" --json`
+- **THEN** the CLI outputs the full API response as formatted JSON to stdout
+
+#### Scenario: Error with --json
+- **WHEN** issue creation fails and `--json` flag is set
+- **THEN** the CLI outputs the error as JSON to stderr (following existing `handleError` pattern)
+
+### Requirement: Input validation
+The CLI SHALL validate inputs before making API calls.
+
+#### Scenario: Invalid projectId format
+- **WHEN** user provides a projectId that is not a valid UUID
+- **THEN** the CLI exits with a validation error: `Invalid projectId: "<value>" is not a valid UUID.`
+
+#### Scenario: Invalid --type value
+- **WHEN** user provides `--type invalid_type`
+- **THEN** the CLI exits with a validation error listing valid types: `api_bug, task`
+
+#### Scenario: Invalid --env value
+- **WHEN** user provides `--env InvalidEnv` for an API Bug issue
+- **THEN** the CLI exits with a validation error listing valid environments: `Local, Dev, Staging, Prod`
+
+#### Scenario: Invalid --status value
+- **WHEN** user provides `--status InvalidStatus`
+- **THEN** the CLI exits with a validation error listing valid statuses
+
+### Requirement: CurlTicketClient API methods
+The `CurlTicketClient` class SHALL expose `parseCurl()` and `createIssue()` methods for the create-issue command.
+
+#### Scenario: parseCurl sends cURL to server
+- **WHEN** `client.parseCurl(curlString)` is called
+- **THEN** it sends `POST /api/curl/parse` with body `{ curl: curlString }` and returns `{ data: { url, method, headers, body } }`
+
+#### Scenario: createIssue sends issue data to server
+- **WHEN** `client.createIssue(projectId, issueData)` is called
+- **THEN** it sends `POST /api/projects/:projectId/issues` with the issue data as body and returns the created issue response

--- a/openspec/changes/archive/2026-04-10-cli-create-issue/tasks.md
+++ b/openspec/changes/archive/2026-04-10-cli-create-issue/tasks.md
@@ -1,0 +1,28 @@
+## 1. Types & API Client
+
+- [x] 1.1 Add `ParseCurlResponse` and `CreateIssueInput` types to `packages/cli/src/types.ts` — `ParseCurlResponse: { data: { url: string, method: string, headers: Record<string, string> | null, body: unknown | null } }`, `CreateIssueInput: { issueType, title, description?, rawCurl?, method?, url?, environment?, requestHeaders?, requestBody?, status? }`
+- [x] 1.2 Add `parseCurl(curl: string)` method to `CurlTicketClient` in `packages/cli/src/api-client.ts` — sends `POST /api/curl/parse` with `{ curl }` body, returns `ParseCurlResponse`
+- [x] 1.3 Add `createIssue(projectId: string, data: CreateIssueInput)` method to `CurlTicketClient` — sends `POST /api/projects/:projectId/issues` with data as body, returns `IssueResponse`
+
+## 2. Interactive Prompt Helpers
+
+- [x] 2.1 Add `promptInput(question: string): Promise<string>` to `packages/cli/src/utils.ts` — uses readline to ask for a single-line text input, returns trimmed answer
+- [x] 2.2 Add `promptSelect(question: string, choices: string[]): Promise<string>` to `packages/cli/src/utils.ts` — displays numbered choices, validates selection, returns the selected choice string
+
+## 3. Command Implementation
+
+- [x] 3.1 Create `packages/cli/src/commands/create-issue.ts` with `createIssueCommand(client, projectId, options, json)` function — validate projectId (UUID); if `--type` not provided and stdin is TTY, prompt user to select between `API Bug` and `Task` via `promptSelect()`; if non-TTY and no `--type`, exit with error; validate type with `normalizeType()`, branch into API Bug or Task flow
+- [x] 3.2 Implement API Bug flow — validate `--curl` is present, call `client.parseCurl()`, auto-generate title as `<METHOD> <url_path>` (override if `--title` provided), validate `--env` against environments list (default `Dev`), call `client.createIssue()` with assembled data
+- [x] 3.3 Implement Task interactive flow — if no `--title` and stdin is TTY: prompt title (re-prompt if empty), show gate menu (Create now / Add details / Cancel), if Add details: prompt Why + Goal, compose Markdown description, preview, confirm, then call `client.createIssue()`
+- [x] 3.4 Implement non-interactive mode — if `--type` and `--title` are both provided, skip all prompts and create directly; if stdin is not TTY and `--type` is missing, exit with error; if stdin is not TTY and `--title` is missing for task type, exit with error
+- [x] 3.5 Implement output — human-readable mode: print `Issue created: <friendlyId> — <title>`; JSON mode: print full API response
+
+## 4. Command Registration
+
+- [x] 4.1 Register `create-issue` command in `packages/cli/src/index.ts` — add Commander definition with positional `<projectId>`, optional `--type <type>` (no longer required — prompted interactively when omitted), optional `--curl`, `--title`, `--description`, `--env`, `--status` options; wire up `withAuth` + `handleError` following existing patterns
+
+## 5. Verification
+
+- [x] 5.1 Run `pnpm lint` from project root — fix any linting issues
+- [x] 5.2 Run `pnpm typecheck` from project root — fix any type errors
+- [x] 5.3 Manual smoke test — build CLI (`cd packages/cli && pnpm build`), test `ct create-issue --help` outputs expected usage, verify command is listed in `ct --help`

--- a/openspec/specs/cli-create-issue/spec.md
+++ b/openspec/specs/cli-create-issue/spec.md
@@ -1,0 +1,130 @@
+## ADDED Requirements
+
+### Requirement: Interactive issue type selection
+The CLI SHALL prompt the user to select between `API Bug` and `Task` when `--type` is not provided and stdin is a TTY.
+
+#### Scenario: No --type flag in interactive terminal
+- **WHEN** user runs `ct create-issue <projectId>` without `--type` in an interactive terminal
+- **THEN** the CLI presents a numbered menu: `1) API Bug  2) Task`
+- **WHEN** user selects `1`
+- **THEN** the CLI proceeds with the API Bug flow
+
+#### Scenario: No --type flag in interactive terminal — select Task
+- **WHEN** user runs `ct create-issue <projectId>` without `--type` in an interactive terminal
+- **THEN** the CLI presents a numbered menu: `1) API Bug  2) Task`
+- **WHEN** user selects `2`
+- **THEN** the CLI proceeds with the Task flow
+
+#### Scenario: No --type in non-TTY environment
+- **WHEN** the command runs in a non-TTY environment without `--type`
+- **THEN** the CLI SHALL exit with an error: `--type is required in non-interactive mode`
+
+#### Scenario: Explicit --type flag skips prompt
+- **WHEN** user runs `ct create-issue <projectId> --type task`
+- **THEN** the CLI skips the type selection prompt and proceeds directly with the Task flow
+
+### Requirement: Create API Bug issue from cURL command
+The CLI SHALL support creating an API Bug issue by accepting a raw cURL command string, parsing it server-side, and submitting the parsed data to create the issue.
+
+#### Scenario: Create API Bug with --curl flag
+- **WHEN** user runs `ct create-issue <projectId> --type api_bug --curl "curl -X POST https://api.example.com/users -H 'Content-Type: application/json' -d '{"name":"test"}'"`
+- **THEN** the CLI calls `POST /api/curl/parse` with the cURL string, receives parsed `{ url, method, headers, body }`, generates a title as `POST /users`, and calls `POST /api/projects/:projectId/issues` with `issueType: "api_bug"` and the parsed data
+- **THEN** the CLI prints the created issue's friendly ID (e.g., `CT-42`) and title
+
+#### Scenario: Create API Bug with --curl and explicit --title
+- **WHEN** user runs `ct create-issue <projectId> --type api_bug --curl "..." --title "Login 500 error"`
+- **THEN** the CLI uses the provided title instead of auto-generating one from the parsed URL
+
+#### Scenario: Create API Bug with --curl and --env
+- **WHEN** user runs `ct create-issue <projectId> --type api_bug --curl "..." --env Prod`
+- **THEN** the created issue has `environment` set to `Prod`
+
+#### Scenario: Create API Bug without --curl flag
+- **WHEN** user runs `ct create-issue <projectId> --type api_bug` without `--curl`
+- **THEN** the CLI SHALL exit with a validation error: `--curl is required for api_bug type`
+
+### Requirement: Create Task issue with interactive guided flow
+The CLI SHALL support creating a Task issue through an interactive guided flow when no `--title` flag is provided and stdin is a TTY.
+
+#### Scenario: Interactive task — create now (minimal)
+- **WHEN** user runs `ct create-issue <projectId> --type task` in an interactive terminal
+- **THEN** the CLI prompts for `Title` (required)
+- **THEN** the CLI presents a gate menu: `Create now` / `Add details` / `Cancel`
+- **WHEN** user selects `Create now`
+- **THEN** the CLI creates the issue with only the title and prints the created issue
+
+#### Scenario: Interactive task — add details
+- **WHEN** user selects `Add details` at the gate menu
+- **THEN** the CLI prompts for `Why (motivation)` and `Goal (expected outcome)`
+- **THEN** the CLI composes a Markdown description with `## Why` and `## Goal` sections
+- **THEN** the CLI shows a preview of the issue (title + description) and asks for confirmation
+- **WHEN** user confirms
+- **THEN** the CLI creates the issue and prints the created issue
+
+#### Scenario: Interactive task — cancel
+- **WHEN** user selects `Cancel` at the gate menu
+- **THEN** the CLI prints `Cancelled.` and exits without creating an issue
+
+#### Scenario: Interactive task — empty title
+- **WHEN** user enters an empty string for the title prompt
+- **THEN** the CLI SHALL re-prompt for the title (title is required)
+
+### Requirement: Non-interactive mode for scripting
+The CLI SHALL support a non-interactive mode that bypasses all prompts when `--title` is provided, enabling use in scripts and CI pipelines.
+
+#### Scenario: Non-interactive task creation
+- **WHEN** user runs `ct create-issue <projectId> --type task --title "Refactor auth module" --description "Clean up the middleware"`
+- **THEN** the CLI creates the issue directly without any prompts
+
+#### Scenario: Non-interactive task with title only
+- **WHEN** user runs `ct create-issue <projectId> --type task --title "Fix bug"`
+- **THEN** the CLI creates the issue with null description, no prompts
+
+#### Scenario: Non-TTY without --title for task type
+- **WHEN** the command runs in a non-TTY environment (e.g., piped input) without `--title` for task type
+- **THEN** the CLI SHALL exit with an error: `--title is required in non-interactive mode`
+
+#### Scenario: Non-TTY without --type
+- **WHEN** the command runs in a non-TTY environment without `--type`
+- **THEN** the CLI SHALL exit with an error: `--type is required in non-interactive mode`
+
+### Requirement: JSON output mode
+The CLI SHALL support `--json` flag to output raw JSON responses, consistent with other commands.
+
+#### Scenario: Create issue with --json
+- **WHEN** user runs `ct create-issue <projectId> --type task --title "Test" --json`
+- **THEN** the CLI outputs the full API response as formatted JSON to stdout
+
+#### Scenario: Error with --json
+- **WHEN** issue creation fails and `--json` flag is set
+- **THEN** the CLI outputs the error as JSON to stderr (following existing `handleError` pattern)
+
+### Requirement: Input validation
+The CLI SHALL validate inputs before making API calls.
+
+#### Scenario: Invalid projectId format
+- **WHEN** user provides a projectId that is not a valid UUID
+- **THEN** the CLI exits with a validation error: `Invalid projectId: "<value>" is not a valid UUID.`
+
+#### Scenario: Invalid --type value
+- **WHEN** user provides `--type invalid_type`
+- **THEN** the CLI exits with a validation error listing valid types: `api_bug, task`
+
+#### Scenario: Invalid --env value
+- **WHEN** user provides `--env InvalidEnv` for an API Bug issue
+- **THEN** the CLI exits with a validation error listing valid environments: `Local, Dev, Staging, Prod`
+
+#### Scenario: Invalid --status value
+- **WHEN** user provides `--status InvalidStatus`
+- **THEN** the CLI exits with a validation error listing valid statuses
+
+### Requirement: CurlTicketClient API methods
+The `CurlTicketClient` class SHALL expose `parseCurl()` and `createIssue()` methods for the create-issue command.
+
+#### Scenario: parseCurl sends cURL to server
+- **WHEN** `client.parseCurl(curlString)` is called
+- **THEN** it sends `POST /api/curl/parse` with body `{ curl: curlString }` and returns `{ data: { url, method, headers, body } }`
+
+#### Scenario: createIssue sends issue data to server
+- **WHEN** `client.createIssue(projectId, issueData)` is called
+- **THEN** it sends `POST /api/projects/:projectId/issues` with the issue data as body and returns the created issue response

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -28,6 +28,8 @@ ct projects
 
 On first run, you'll be prompted to enter your Curl Ticket instance URL, then a browser window will open for authentication. Your credentials are saved locally at `~/.config/curl-ticket/config.json`.
 
+For local development and manual QA, see [TESTING.md](./TESTING.md).
+
 ### Commands
 
 #### Projects
@@ -196,6 +198,8 @@ ct projects
 ```
 
 首次執行時，系統會提示你輸入 Curl Ticket 站台網址，接著開啟瀏覽器進行登入驗證。登入資訊會儲存在 `~/.config/curl-ticket/config.json`。
+
+若要進行本地開發與手動測試，請參考 [TESTING.md](./TESTING.md)。
 
 ### 指令
 

--- a/packages/cli/TESTING.md
+++ b/packages/cli/TESTING.md
@@ -1,0 +1,278 @@
+# CLI Manual Testing Guide
+
+This guide documents the standard local testing flow for `@curl-ticket/cli`.
+
+## Scope
+
+Use this guide when you need to:
+
+- verify CLI behavior during local development
+- test interactive prompts
+- test real API calls against a non-production project
+- verify global install or link behavior before release
+
+## Rules
+
+- Prefer a dedicated test project such as `FTT / Test Project`.
+- Do not test destructive flows against production projects.
+- Treat pasted cURL commands as sensitive input. Avoid sharing bearer tokens in logs or screenshots.
+- During development, test `dist/index.js` directly instead of `ct` unless you are explicitly testing the global install experience.
+
+## Standard Development Loop
+
+Run the build watcher in one terminal:
+
+```bash
+cd /Users/wenkmedia/Desktop/Curl-Ticket/packages/cli
+pnpm dev
+```
+
+This keeps `dist/index.js` up to date after every source edit.
+
+Use another terminal to run the compiled CLI:
+
+```bash
+cd /Users/wenkmedia/Desktop/Curl-Ticket/packages/cli
+node dist/index.js projects
+node dist/index.js project <projectId>
+node dist/index.js create-issue <projectId>
+```
+
+## Why Test `dist/index.js`
+
+The CLI `bin` entry points to `dist/index.js`, not `src/index.ts`.
+
+```json
+"bin": {
+  "ct": "./dist/index.js",
+  "curl-ticket": "./dist/index.js"
+}
+```
+
+If you change files under `src/` but do not rebuild, a global `ct` command can still run stale code.
+
+## Pre-Commit Verification
+
+Before committing or preparing a release, run:
+
+```bash
+cd /Users/wenkmedia/Desktop/Curl-Ticket/packages/cli
+pnpm typecheck
+pnpm build
+
+cd /Users/wenkmedia/Desktop/Curl-Ticket
+pnpm test:run -- packages/cli/src/__tests__/utils.test.ts packages/cli/src/__tests__/commands-create-issue.test.ts
+```
+
+If you changed other CLI areas, expand the test selection accordingly.
+
+## Core Manual Test Cases
+
+### Authentication and Connectivity
+
+```bash
+cd /Users/wenkmedia/Desktop/Curl-Ticket/packages/cli
+node dist/index.js projects
+```
+
+Verify:
+
+- the CLI can read local auth config or environment variables
+- the target instance is reachable
+- project listing succeeds
+
+### Create Task Issue
+
+Non-interactive:
+
+```bash
+node dist/index.js create-issue <projectId> --type task --title '0410 Create Test'
+```
+
+Interactive:
+
+```bash
+node dist/index.js create-issue <projectId>
+```
+
+Then select:
+
+```text
+1) API Bug
+2) Task
+```
+
+Verify:
+
+- task creation succeeds
+- the returned issue title matches the provided title
+
+### Create API Bug from cURL
+
+Interactive:
+
+```bash
+node dist/index.js create-issue <projectId>
+```
+
+Then select `API Bug` and paste a full multi-line cURL command in one shot.
+
+Example:
+
+```bash
+curl 'https://example.com/api/test' \
+-H 'accept: application/json' \
+--data-raw '{"ok":true}'
+```
+
+Verify:
+
+- the pasted multi-line cURL is accepted without line-by-line manual confirmation
+- the parser succeeds
+- the created issue title is auto-generated from HTTP method and URL path
+- headers and request body are preserved
+
+### JSON Mode
+
+```bash
+node dist/index.js projects --json
+node dist/index.js issue <projectId> <issueId> --json
+```
+
+Verify:
+
+- valid JSON is returned
+- errors also render as JSON when `--json` is present
+
+### Error Handling
+
+Verify at least one case from each category:
+
+- invalid `projectId`
+- invalid status
+- missing required option in non-interactive mode
+- unauthorized or expired token
+- network failure
+
+## Global Install or Link Verification
+
+Only do this when you specifically need to test the end-user install experience.
+
+### Link Local Workspace Globally
+
+```bash
+cd /Users/wenkmedia/Desktop/Curl-Ticket/packages/cli
+pnpm link --global
+```
+
+Check what your shell resolves:
+
+```bash
+which ct
+which curl-ticket
+```
+
+If needed, inspect the shim to confirm it points to this workspace:
+
+```bash
+sed -n '1,80p' ~/Library/pnpm/ct
+```
+
+### Important Caveat
+
+Even with a global link, the executed entry is still `dist/index.js`. Keep `pnpm dev` running or rebuild manually after source changes:
+
+```bash
+cd /Users/wenkmedia/Desktop/Curl-Ticket/packages/cli
+pnpm build
+```
+
+### Clean Up Global Test Install
+
+When you are done testing, remove the global package:
+
+```bash
+pnpm remove --global @curl-ticket/cli
+```
+
+Then confirm cleanup:
+
+```bash
+which ct
+which curl-ticket
+```
+
+Expected result:
+
+- `ct not found`
+- `curl-ticket not found`
+
+## Suggested Test Project Workflow
+
+Recommended sequence for interactive verification:
+
+1. List projects and choose a safe test project.
+2. Create one `task` issue.
+3. Create one `api_bug` issue from a multi-line cURL.
+4. Inspect the created issue details.
+5. Delete test issues if they are no longer needed.
+
+## Troubleshooting
+
+### CLI runs old behavior
+
+Cause:
+
+- `dist/index.js` is stale
+- global `ct` still points to a local workspace build
+
+Fix:
+
+```bash
+cd /Users/wenkmedia/Desktop/Curl-Ticket/packages/cli
+pnpm build
+```
+
+Then rerun with:
+
+```bash
+node dist/index.js ...
+```
+
+### `unlink` says nothing to unlink
+
+Cause:
+
+- the CLI was installed globally rather than linked in a way `pnpm unlink --global` recognizes
+
+Fix:
+
+```bash
+pnpm remove --global @curl-ticket/cli
+```
+
+### Interactive create-issue cannot parse pasted cURL
+
+Check:
+
+- you are running the latest `dist/index.js`
+- the pasted command is a valid shell cURL
+- the target API parser is reachable
+
+## Short Version
+
+For most local feature work:
+
+```bash
+cd /Users/wenkmedia/Desktop/Curl-Ticket/packages/cli
+pnpm dev
+```
+
+In another terminal:
+
+```bash
+cd /Users/wenkmedia/Desktop/Curl-Ticket/packages/cli
+node dist/index.js create-issue <projectId>
+```
+
+Only use global install or link when you are explicitly testing install behavior.

--- a/packages/cli/skills/curl-ticket/SKILL.md
+++ b/packages/cli/skills/curl-ticket/SKILL.md
@@ -20,6 +20,8 @@ curl-ticket project <projectId> --json                                 # Project
 curl-ticket create-project --name "X" --key "X" --json                 # Create project
 curl-ticket members <projectId> --json                                 # List project members
 curl-ticket issues <projectId> --json [-s Open] [-t api_bug] [-n 10]  # List issues
+curl-ticket create-issue <projectId> --type api_bug --curl "..." --json  # Create API Bug from cURL
+curl-ticket create-issue <projectId> --type task --title "..." --json    # Create Task issue
 curl-ticket issue <projectId> <issueId|CT-42> --json                   # Issue details
 curl-ticket issue <projectId> <issueId> --json --fields status,url,method  # Fetch only specific fields (saves tokens)
 curl-ticket update-status <projectId> <issueId> <status> --json        # Update status (Open|in-progress|Done|Close)

--- a/packages/cli/skills/curl-ticket/SKILL.md
+++ b/packages/cli/skills/curl-ticket/SKILL.md
@@ -20,8 +20,8 @@ curl-ticket project <projectId> --json                                 # Project
 curl-ticket create-project --name "X" --key "X" --json                 # Create project
 curl-ticket members <projectId> --json                                 # List project members
 curl-ticket issues <projectId> --json [-s Open] [-t api_bug] [-n 10]  # List issues
-curl-ticket create-issue <projectId> --type api_bug --curl "..." --json  # Create API Bug from cURL
-curl-ticket create-issue <projectId> --type task --title "..." --json    # Create Task issue
+curl-ticket create-issue <projectId> --type api_bug --curl "..." --description "## Steps\n..." --json  # Create API Bug (description supports Markdown)
+curl-ticket create-issue <projectId> --type task --title "..." --description "## Why\n..." --json  # Create Task (description supports Markdown)
 curl-ticket issue <projectId> <issueId|CT-42> --json                   # Issue details
 curl-ticket issue <projectId> <issueId> --json --fields status,url,method  # Fetch only specific fields (saves tokens)
 curl-ticket update-status <projectId> <issueId> <status> --json        # Update status (Open|in-progress|Done|Close)

--- a/packages/cli/src/__tests__/commands-create-issue-interactive.test.ts
+++ b/packages/cli/src/__tests__/commands-create-issue-interactive.test.ts
@@ -1,0 +1,240 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { createIssueCommand } from '../commands/create-issue.js'
+import { parseCurlResponse, createApiBugResponse, createTaskResponse } from './fixtures.js'
+import type { CurlTicketClient } from '../api-client.js'
+
+const mockSelect = vi.fn()
+const mockInput = vi.fn()
+const mockConfirm = vi.fn()
+const mockEditor = vi.fn()
+
+vi.mock('../utils.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../utils.js')>()
+  class MockPrompter {
+    select = mockSelect
+    input = mockInput
+    confirm = mockConfirm
+    editor = mockEditor
+    close = vi.fn()
+  }
+  return {
+    ...actual,
+    Prompter: MockPrompter
+  }
+})
+
+// Make process.stdin.isTTY truthy so Prompter is created
+vi.stubGlobal('process', {
+  ...process,
+  stdin: { ...process.stdin, isTTY: true }
+})
+
+const PROJECT_ID = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890'
+
+function createMockClient(overrides: Partial<CurlTicketClient> = {}): CurlTicketClient {
+  return {
+    parseCurl: vi.fn().mockResolvedValue(parseCurlResponse),
+    createIssue: vi.fn().mockResolvedValue(createApiBugResponse),
+    ...overrides
+  } as unknown as CurlTicketClient
+}
+
+describe('createIssueCommand (interactive)', () => {
+  let stderrSpy: ReturnType<typeof vi.spyOn>
+  let consoleSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    vi.spyOn(process.stdout, 'write').mockReturnValue(true)
+    stderrSpy = vi.spyOn(process.stderr, 'write').mockReturnValue(true)
+    consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    mockSelect.mockReset()
+    mockInput.mockReset()
+    mockConfirm.mockReset()
+    mockEditor.mockReset()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  // ------------------------------------------------------------------
+  // Interactive type selection
+  // ------------------------------------------------------------------
+  describe('type selection', () => {
+    it('selects API Bug via interactive prompt and creates api_bug issue', async () => {
+      mockSelect.mockResolvedValueOnce('API Bug')
+      mockEditor.mockResolvedValueOnce('curl https://api.example.com/users/123')
+
+      const client = createMockClient()
+      await createIssueCommand(client, PROJECT_ID, {}, false)
+
+      expect(mockSelect).toHaveBeenCalledWith('Select issue type', ['API Bug', 'Task'])
+      expect(client.parseCurl).toHaveBeenCalled()
+      expect(client.createIssue).toHaveBeenCalledWith(
+        PROJECT_ID,
+        expect.objectContaining({ issueType: 'api_bug' })
+      )
+    })
+
+    it('selects Task via interactive prompt and creates task issue', async () => {
+      mockSelect.mockResolvedValueOnce('Task')
+      mockInput.mockResolvedValueOnce('My task title')
+      mockConfirm
+        .mockResolvedValueOnce(false) // Add description? → No
+        .mockResolvedValueOnce(true) // Create this issue? → Yes
+
+      const client = createMockClient({
+        createIssue: vi.fn().mockResolvedValue(createTaskResponse)
+      })
+      await createIssueCommand(client, PROJECT_ID, {}, false)
+
+      expect(mockSelect).toHaveBeenCalledWith('Select issue type', ['API Bug', 'Task'])
+      expect(client.createIssue).toHaveBeenCalledWith(
+        PROJECT_ID,
+        expect.objectContaining({ issueType: 'task', title: 'My task title' })
+      )
+    })
+  })
+
+  // ------------------------------------------------------------------
+  // Task interactive flow
+  // ------------------------------------------------------------------
+  describe('task flow — interactive', () => {
+    it('creates task with title only when description is skipped', async () => {
+      mockSelect.mockResolvedValueOnce('Task')
+      mockInput.mockResolvedValueOnce('Quick task')
+      mockConfirm
+        .mockResolvedValueOnce(false) // Add description? → No
+        .mockResolvedValueOnce(true) // Create this issue? → Yes
+
+      const client = createMockClient({
+        createIssue: vi.fn().mockResolvedValue(createTaskResponse)
+      })
+      await createIssueCommand(client, PROJECT_ID, {}, false)
+
+      expect(client.createIssue).toHaveBeenCalledWith(
+        PROJECT_ID,
+        expect.objectContaining({ issueType: 'task', title: 'Quick task' })
+      )
+      expect(mockEditor).not.toHaveBeenCalled()
+      expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Issue created:'))
+    })
+
+    it('creates task with title and Markdown description via editor', async () => {
+      mockSelect.mockResolvedValueOnce('Task')
+      mockInput.mockResolvedValueOnce('Rate limiting')
+      mockConfirm
+        .mockResolvedValueOnce(true) // Add description? → Yes
+        .mockResolvedValueOnce(true) // Create this issue? → Yes
+      mockEditor.mockResolvedValueOnce('## Why\nToo many requests\n\n## Goal\n100 req/s')
+
+      const client = createMockClient({
+        createIssue: vi.fn().mockResolvedValue(createTaskResponse)
+      })
+      await createIssueCommand(client, PROJECT_ID, {}, false)
+
+      expect(mockEditor).toHaveBeenCalledWith('Description (Markdown supported)')
+      expect(client.createIssue).toHaveBeenCalledWith(
+        PROJECT_ID,
+        expect.objectContaining({
+          issueType: 'task',
+          title: 'Rate limiting',
+          description: '## Why\nToo many requests\n\n## Goal\n100 req/s'
+        })
+      )
+    })
+
+    it('cancels when user rejects confirmation', async () => {
+      mockSelect.mockResolvedValueOnce('Task')
+      mockInput.mockResolvedValueOnce('Will cancel')
+      mockConfirm
+        .mockResolvedValueOnce(false) // Add description? → No
+        .mockResolvedValueOnce(false) // Create this issue? → No
+
+      const client = createMockClient()
+      await createIssueCommand(client, PROJECT_ID, {}, false)
+
+      expect(client.createIssue).not.toHaveBeenCalled()
+      expect(stderrSpy).toHaveBeenCalledWith('Cancelled.\n')
+    })
+
+    it('shows preview before confirmation', async () => {
+      mockSelect.mockResolvedValueOnce('Task')
+      mockInput.mockResolvedValueOnce('My title')
+      mockConfirm
+        .mockResolvedValueOnce(true) // Add description? → Yes
+        .mockResolvedValueOnce(true) // Create this issue? → Yes
+      mockEditor.mockResolvedValueOnce('## Details\nSome markdown')
+
+      const client = createMockClient({
+        createIssue: vi.fn().mockResolvedValue(createTaskResponse)
+      })
+      await createIssueCommand(client, PROJECT_ID, {}, false)
+
+      const output = stderrSpy.mock.calls.map((c: [string]) => c[0]).join('')
+      expect(output).toContain('--- Preview ---')
+      expect(output).toContain('Title: My title')
+      expect(output).toContain('## Details\nSome markdown')
+      expect(output).toContain('--- End Preview ---')
+    })
+  })
+
+  // ------------------------------------------------------------------
+  // API Bug interactive flow
+  // ------------------------------------------------------------------
+  describe('api_bug flow — interactive', () => {
+    it('opens editor for cURL when --curl is not provided', async () => {
+      mockSelect.mockResolvedValueOnce('API Bug')
+      mockEditor.mockResolvedValueOnce('curl https://api.example.com/users/123')
+      mockConfirm.mockResolvedValueOnce(false) // Add description? → No
+
+      const client = createMockClient()
+      await createIssueCommand(client, PROJECT_ID, {}, false)
+
+      expect(mockEditor).toHaveBeenCalledWith('Paste cURL command')
+      expect(client.parseCurl).toHaveBeenCalledWith('curl https://api.example.com/users/123')
+    })
+
+    it('creates api_bug with Markdown description via editor', async () => {
+      mockSelect.mockResolvedValueOnce('API Bug')
+      mockEditor
+        .mockResolvedValueOnce('curl https://api.example.com/users/123')
+        .mockResolvedValueOnce('## Steps\n1. Call endpoint\n2. Get 500')
+      mockConfirm.mockResolvedValueOnce(true) // Add description? → Yes
+
+      const client = createMockClient()
+      await createIssueCommand(client, PROJECT_ID, {}, false)
+
+      expect(mockEditor).toHaveBeenCalledWith('Description (Markdown supported)')
+      expect(client.createIssue).toHaveBeenCalledWith(
+        PROJECT_ID,
+        expect.objectContaining({
+          issueType: 'api_bug',
+          description: '## Steps\n1. Call endpoint\n2. Get 500'
+        })
+      )
+    })
+
+    it('skips description when user declines', async () => {
+      mockSelect.mockResolvedValueOnce('API Bug')
+      mockEditor.mockResolvedValueOnce('curl https://api.example.com/users/123')
+      mockConfirm.mockResolvedValueOnce(false) // Add description? → No
+
+      const client = createMockClient()
+      await createIssueCommand(client, PROJECT_ID, {}, false)
+
+      const payload = vi.mocked(client.createIssue).mock.calls[0][1]
+      expect(payload).not.toHaveProperty('description')
+    })
+
+    it('throws ValidationError when editor returns empty cURL', async () => {
+      mockSelect.mockResolvedValueOnce('API Bug')
+      mockEditor.mockResolvedValueOnce('')
+
+      const client = createMockClient()
+      await expect(createIssueCommand(client, PROJECT_ID, {}, false)).rejects.toThrow(
+        'cURL command cannot be empty.'
+      )
+    })
+  })
+})

--- a/packages/cli/src/__tests__/commands-create-issue.test.ts
+++ b/packages/cli/src/__tests__/commands-create-issue.test.ts
@@ -1,0 +1,292 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { createIssueCommand } from '../commands/create-issue.js'
+import {
+  parseCurlResponse,
+  parseCurlPostResponse,
+  createApiBugResponse,
+  createTaskResponse
+} from './fixtures.js'
+import type { CurlTicketClient } from '../api-client.js'
+import { ValidationError } from '../utils.js'
+
+const PROJECT_ID = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890'
+
+function createMockClient(
+  overrides: Partial<CurlTicketClient> = {}
+): CurlTicketClient {
+  return {
+    parseCurl: vi.fn().mockResolvedValue(parseCurlResponse),
+    createIssue: vi.fn().mockResolvedValue(createApiBugResponse),
+    ...overrides
+  } as unknown as CurlTicketClient
+}
+
+describe('createIssueCommand', () => {
+  let stdoutSpy: ReturnType<typeof vi.spyOn>
+  let consoleSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    stdoutSpy = vi.spyOn(process.stdout, 'write').mockReturnValue(true)
+    consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  // ------------------------------------------------------------------
+  // api_bug flow
+  // ------------------------------------------------------------------
+  describe('api_bug flow', () => {
+    it('creates an api_bug issue from cURL', async () => {
+      const client = createMockClient()
+      await createIssueCommand(
+        client,
+        PROJECT_ID,
+        { type: 'api_bug', curl: 'curl https://api.example.com/users/123' },
+        false
+      )
+
+      expect(client.parseCurl).toHaveBeenCalledWith(
+        'curl https://api.example.com/users/123'
+      )
+      expect(client.createIssue).toHaveBeenCalledWith(PROJECT_ID, {
+        issueType: 'api_bug',
+        title: 'GET /users/123',
+        rawCurl: 'curl https://api.example.com/users/123',
+        method: 'GET',
+        url: 'https://api.example.com/users/123',
+        environment: 'Dev',
+        requestHeaders: { Authorization: 'Bearer token123', Accept: 'application/json' },
+        requestBody: null
+      })
+      expect(consoleSpy).toHaveBeenCalledWith('Issue created: BA-5 — GET /users/123')
+    })
+
+    it('uses custom title when --title is provided', async () => {
+      const client = createMockClient()
+      await createIssueCommand(
+        client,
+        PROJECT_ID,
+        { type: 'api_bug', curl: 'curl https://api.example.com/users/123', title: 'Custom title' },
+        false
+      )
+
+      const call = vi.mocked(client.createIssue).mock.calls[0][1]
+      expect(call.title).toBe('Custom title')
+    })
+
+    it('auto-generates title from parsed method + URL path', async () => {
+      const client = createMockClient({
+        parseCurl: vi.fn().mockResolvedValue(parseCurlPostResponse),
+        createIssue: vi.fn().mockResolvedValue(createApiBugResponse)
+      })
+      await createIssueCommand(
+        client,
+        PROJECT_ID,
+        { type: 'api_bug', curl: 'curl -X POST https://api.example.com/users' },
+        false
+      )
+
+      const call = vi.mocked(client.createIssue).mock.calls[0][1]
+      expect(call.title).toBe('POST /users')
+    })
+
+    it('passes --env through normalizeEnvironment (case-insensitive)', async () => {
+      const client = createMockClient()
+      await createIssueCommand(
+        client,
+        PROJECT_ID,
+        { type: 'api_bug', curl: 'curl https://example.com', env: 'staging' },
+        false
+      )
+
+      const call = vi.mocked(client.createIssue).mock.calls[0][1]
+      expect(call.environment).toBe('Staging')
+    })
+
+    it('passes description and status when provided', async () => {
+      const client = createMockClient()
+      await createIssueCommand(
+        client,
+        PROJECT_ID,
+        {
+          type: 'api_bug',
+          curl: 'curl https://example.com',
+          description: 'Some detail',
+          status: 'in-progress'
+        },
+        false
+      )
+
+      const call = vi.mocked(client.createIssue).mock.calls[0][1]
+      expect(call.description).toBe('Some detail')
+      expect(call.status).toBe('In Progress')
+    })
+
+    it('throws ValidationError when --curl is missing for api_bug', async () => {
+      const client = createMockClient()
+      await expect(
+        createIssueCommand(client, PROJECT_ID, { type: 'api_bug' }, false)
+      ).rejects.toThrow(ValidationError)
+    })
+
+    it('outputs JSON when --json is set', async () => {
+      const client = createMockClient()
+      await createIssueCommand(
+        client,
+        PROJECT_ID,
+        { type: 'api_bug', curl: 'curl https://example.com' },
+        true
+      )
+
+      expect(stdoutSpy).toHaveBeenCalledOnce()
+      const output = stdoutSpy.mock.calls[0][0] as string
+      expect(JSON.parse(output)).toEqual(createApiBugResponse)
+      expect(consoleSpy).not.toHaveBeenCalled()
+    })
+  })
+
+  // ------------------------------------------------------------------
+  // task flow
+  // ------------------------------------------------------------------
+  describe('task flow', () => {
+    it('creates a task issue with --title', async () => {
+      const client = createMockClient({
+        createIssue: vi.fn().mockResolvedValue(createTaskResponse)
+      })
+      await createIssueCommand(
+        client,
+        PROJECT_ID,
+        { type: 'task', title: 'Implement rate limiting' },
+        false
+      )
+
+      expect(client.parseCurl).not.toHaveBeenCalled()
+      expect(client.createIssue).toHaveBeenCalledWith(PROJECT_ID, {
+        issueType: 'task',
+        title: 'Implement rate limiting'
+      })
+      expect(consoleSpy).toHaveBeenCalledWith(
+        'Issue created: BA-6 — Implement rate limiting'
+      )
+    })
+
+    it('includes description when provided', async () => {
+      const client = createMockClient({
+        createIssue: vi.fn().mockResolvedValue(createTaskResponse)
+      })
+      await createIssueCommand(
+        client,
+        PROJECT_ID,
+        { type: 'task', title: 'Task A', description: 'Details here' },
+        false
+      )
+
+      const call = vi.mocked(client.createIssue).mock.calls[0][1]
+      expect(call.description).toBe('Details here')
+    })
+
+    it('includes status when provided', async () => {
+      const client = createMockClient({
+        createIssue: vi.fn().mockResolvedValue(createTaskResponse)
+      })
+      await createIssueCommand(
+        client,
+        PROJECT_ID,
+        { type: 'task', title: 'Task A', status: 'Done' },
+        false
+      )
+
+      const call = vi.mocked(client.createIssue).mock.calls[0][1]
+      expect(call.status).toBe('Done')
+    })
+
+    it('throws ValidationError without --title in non-interactive mode', async () => {
+      const client = createMockClient()
+      // process.stdin.isTTY is undefined in test environment (non-interactive)
+      await expect(
+        createIssueCommand(client, PROJECT_ID, { type: 'task' }, false)
+      ).rejects.toThrow(ValidationError)
+    })
+
+    it('outputs JSON when --json is set', async () => {
+      const client = createMockClient({
+        createIssue: vi.fn().mockResolvedValue(createTaskResponse)
+      })
+      await createIssueCommand(
+        client,
+        PROJECT_ID,
+        { type: 'task', title: 'Task A' },
+        true
+      )
+
+      expect(stdoutSpy).toHaveBeenCalledOnce()
+      const output = stdoutSpy.mock.calls[0][0] as string
+      expect(JSON.parse(output)).toEqual(createTaskResponse)
+    })
+  })
+
+  // ------------------------------------------------------------------
+  // validation
+  // ------------------------------------------------------------------
+  describe('validation', () => {
+    it('throws ValidationError for invalid projectId', async () => {
+      const client = createMockClient()
+      await expect(
+        createIssueCommand(client, 'not-a-uuid', { type: 'api_bug', curl: 'curl x' }, false)
+      ).rejects.toThrow(ValidationError)
+    })
+
+    it('throws ValidationError for invalid --type', async () => {
+      const client = createMockClient()
+      await expect(
+        createIssueCommand(client, PROJECT_ID, { type: 'invalid' }, false)
+      ).rejects.toThrow(ValidationError)
+    })
+
+    it('throws ValidationError for invalid --env', async () => {
+      const client = createMockClient()
+      await expect(
+        createIssueCommand(
+          client,
+          PROJECT_ID,
+          { type: 'api_bug', curl: 'curl x', env: 'invalid' },
+          false
+        )
+      ).rejects.toThrow(ValidationError)
+    })
+
+    it('throws ValidationError for invalid --status', async () => {
+      const client = createMockClient()
+      await expect(
+        createIssueCommand(
+          client,
+          PROJECT_ID,
+          { type: 'api_bug', curl: 'curl x', status: 'bogus' },
+          false
+        )
+      ).rejects.toThrow(ValidationError)
+    })
+
+    it('throws when --type is missing in non-interactive mode', async () => {
+      const client = createMockClient()
+      await expect(
+        createIssueCommand(client, PROJECT_ID, {}, false)
+      ).rejects.toThrow(ValidationError)
+    })
+
+    it('normalizes type case-insensitively (API_BUG → api_bug)', async () => {
+      const client = createMockClient()
+      await createIssueCommand(
+        client,
+        PROJECT_ID,
+        { type: 'API_BUG', curl: 'curl https://example.com' },
+        false
+      )
+
+      const call = vi.mocked(client.createIssue).mock.calls[0][1]
+      expect(call.issueType).toBe('api_bug')
+    })
+  })
+})

--- a/packages/cli/src/__tests__/commands-create-issue.test.ts
+++ b/packages/cli/src/__tests__/commands-create-issue.test.ts
@@ -11,9 +11,7 @@ import { ValidationError } from '../utils.js'
 
 const PROJECT_ID = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890'
 
-function createMockClient(
-  overrides: Partial<CurlTicketClient> = {}
-): CurlTicketClient {
+function createMockClient(overrides: Partial<CurlTicketClient> = {}): CurlTicketClient {
   return {
     parseCurl: vi.fn().mockResolvedValue(parseCurlResponse),
     createIssue: vi.fn().mockResolvedValue(createApiBugResponse),
@@ -47,9 +45,7 @@ describe('createIssueCommand', () => {
         false
       )
 
-      expect(client.parseCurl).toHaveBeenCalledWith(
-        'curl https://api.example.com/users/123'
-      )
+      expect(client.parseCurl).toHaveBeenCalledWith('curl https://api.example.com/users/123')
       expect(client.createIssue).toHaveBeenCalledWith(PROJECT_ID, {
         issueType: 'api_bug',
         title: 'GET /users/123',
@@ -167,9 +163,7 @@ describe('createIssueCommand', () => {
         issueType: 'task',
         title: 'Implement rate limiting'
       })
-      expect(consoleSpy).toHaveBeenCalledWith(
-        'Issue created: BA-6 — Implement rate limiting'
-      )
+      expect(consoleSpy).toHaveBeenCalledWith('Issue created: BA-6 — Implement rate limiting')
     })
 
     it('includes description when provided', async () => {
@@ -205,21 +199,16 @@ describe('createIssueCommand', () => {
     it('throws ValidationError without --title in non-interactive mode', async () => {
       const client = createMockClient()
       // process.stdin.isTTY is undefined in test environment (non-interactive)
-      await expect(
-        createIssueCommand(client, PROJECT_ID, { type: 'task' }, false)
-      ).rejects.toThrow(ValidationError)
+      await expect(createIssueCommand(client, PROJECT_ID, { type: 'task' }, false)).rejects.toThrow(
+        ValidationError
+      )
     })
 
     it('outputs JSON when --json is set', async () => {
       const client = createMockClient({
         createIssue: vi.fn().mockResolvedValue(createTaskResponse)
       })
-      await createIssueCommand(
-        client,
-        PROJECT_ID,
-        { type: 'task', title: 'Task A' },
-        true
-      )
+      await createIssueCommand(client, PROJECT_ID, { type: 'task', title: 'Task A' }, true)
 
       expect(stdoutSpy).toHaveBeenCalledOnce()
       const output = stdoutSpy.mock.calls[0][0] as string
@@ -271,9 +260,9 @@ describe('createIssueCommand', () => {
 
     it('throws when --type is missing in non-interactive mode', async () => {
       const client = createMockClient()
-      await expect(
-        createIssueCommand(client, PROJECT_ID, {}, false)
-      ).rejects.toThrow(ValidationError)
+      await expect(createIssueCommand(client, PROJECT_ID, {}, false)).rejects.toThrow(
+        ValidationError
+      )
     })
 
     it('normalizes type case-insensitively (API_BUG → api_bug)', async () => {

--- a/packages/cli/src/__tests__/commands-project.test.ts
+++ b/packages/cli/src/__tests__/commands-project.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, type MockInstance } from 'vitest'
 import { projectCommand } from '../commands/project.js'
 import { projectDetailResponse } from './fixtures.js'
 import type { CurlTicketClient } from '../api-client.js'
@@ -12,8 +12,8 @@ function createMockClient(response: unknown): CurlTicketClient {
 const PROJECT_ID = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890'
 
 describe('projectCommand', () => {
-  let stdoutSpy: ReturnType<typeof vi.spyOn>
-  let consoleSpy: ReturnType<typeof vi.spyOn>
+  let stdoutSpy: MockInstance<typeof process.stdout.write>
+  let consoleSpy: MockInstance<typeof console.log>
 
   beforeEach(() => {
     stdoutSpy = vi.spyOn(process.stdout, 'write').mockReturnValue(true)

--- a/packages/cli/src/__tests__/fixtures.ts
+++ b/packages/cli/src/__tests__/fixtures.ts
@@ -1,13 +1,16 @@
 import type {
   Project,
   IssueSummary,
+  IssueDetail,
   Pagination,
   ProjectsResponse,
   IssuesResponse,
+  IssueResponse,
   ProjectDetailResponse,
   MembersResponse,
   Member,
-  DeleteResponse
+  DeleteResponse,
+  ParseCurlResponse
 } from '../types.js'
 
 // --- Pagination fixtures ---
@@ -161,4 +164,80 @@ export const membersResponseEmpty: MembersResponse = {
 
 export const deleteSuccessResponse: DeleteResponse = {
   success: true
+}
+
+// --- ParseCurl fixtures ---
+
+export const parseCurlResponse: ParseCurlResponse = {
+  data: {
+    url: 'https://api.example.com/users/123',
+    method: 'GET',
+    headers: { Authorization: 'Bearer token123', Accept: 'application/json' },
+    body: null
+  }
+}
+
+export const parseCurlPostResponse: ParseCurlResponse = {
+  data: {
+    url: 'https://api.example.com/users',
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: { name: 'Alice' }
+  }
+}
+
+// --- IssueDetail / IssueResponse fixtures ---
+
+export const issueDetailApiBug: IssueDetail = {
+  id: 10,
+  issueNumber: 5,
+  projectId: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+  projectKey: 'BA',
+  issueType: 'api_bug' as const,
+  title: 'GET /users/123',
+  description: null,
+  method: 'GET',
+  url: 'https://api.example.com/users/123',
+  environment: 'Dev',
+  rawCurl: 'curl https://api.example.com/users/123',
+  requestHeaders: { Accept: 'application/json' },
+  requestBody: null,
+  responseBody: null,
+  responseStatus: null,
+  status: 'Open' as const,
+  createdBy: 'user-001',
+  createdAt: '2026-04-10T09:00:00.000Z',
+  updatedAt: '2026-04-10T09:00:00.000Z'
+}
+
+export const issueDetailTask: IssueDetail = {
+  id: 11,
+  issueNumber: 6,
+  projectId: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+  projectKey: 'BA',
+  issueType: 'task' as const,
+  title: 'Implement rate limiting',
+  description: '## Why\nPerformance\n\n## Goal\nLimit to 100 req/s',
+  method: null,
+  url: null,
+  environment: null,
+  rawCurl: null,
+  requestHeaders: null,
+  requestBody: null,
+  responseBody: null,
+  responseStatus: null,
+  status: 'Open' as const,
+  createdBy: 'user-001',
+  createdAt: '2026-04-10T09:30:00.000Z',
+  updatedAt: '2026-04-10T09:30:00.000Z'
+}
+
+export const createApiBugResponse: IssueResponse = {
+  data: issueDetailApiBug,
+  friendlyId: 'BA-5'
+}
+
+export const createTaskResponse: IssueResponse = {
+  data: issueDetailTask,
+  friendlyId: 'BA-6'
 }

--- a/packages/cli/src/__tests__/utils.test.ts
+++ b/packages/cli/src/__tests__/utils.test.ts
@@ -84,7 +84,7 @@ describe('Prompter.input', () => {
     const prompter = new TestPrompter([
       "curl 'https://example.com' \\",
       "-H 'accept: application/json' \\",
-      "--data-raw '{\"ok\":true}'"
+      '--data-raw \'{"ok":true}\''
     ])
 
     const value = await prompter.input('cURL command', {
@@ -95,7 +95,7 @@ describe('Prompter.input', () => {
       [
         "curl 'https://example.com' \\",
         "-H 'accept: application/json' \\",
-        "--data-raw '{\"ok\":true}'"
+        '--data-raw \'{"ok":true}\''
       ].join('\n')
     )
     expect(prompter.prompts).toEqual(['cURL command: ', '... ', '... '])
@@ -104,7 +104,9 @@ describe('Prompter.input', () => {
   it('throws when stdin closes before any answer is completed', async () => {
     const prompter = new TestPrompter([null])
 
-    await expect(prompter.input('cURL command')).rejects.toThrow(ValidationError)
+    await expect(prompter.input('cURL command', { continueWhile: () => false })).rejects.toThrow(
+      ValidationError
+    )
   })
 
   it('auto-submits a pasted multi-line cURL after input goes idle', async () => {
@@ -117,7 +119,7 @@ describe('Prompter.input', () => {
 
     rl.emit('line', "curl 'https://example.com/api/test' \\")
     rl.emit('line', "-H 'accept: application/json' \\")
-    rl.emit('line', "--data-raw '{\"ok\":true}'")
+    rl.emit('line', '--data-raw \'{"ok":true}\'')
 
     let settled = false
     valuePromise.then(() => {
@@ -133,7 +135,7 @@ describe('Prompter.input', () => {
       [
         "curl 'https://example.com/api/test' \\",
         "-H 'accept: application/json' \\",
-        "--data-raw '{\"ok\":true}'"
+        '--data-raw \'{"ok":true}\''
       ].join('\n')
     )
     expect(rl.prompts).toEqual(['cURL command: ', '... ', '... '])

--- a/packages/cli/src/__tests__/utils.test.ts
+++ b/packages/cli/src/__tests__/utils.test.ts
@@ -1,0 +1,141 @@
+import { EventEmitter } from 'node:events'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { Prompter, ValidationError, hasTrailingLineContinuation } from '../utils.js'
+
+class TestPrompter extends Prompter {
+  readonly prompts: string[] = []
+
+  constructor(private readonly answers: Array<string | null>) {
+    super()
+  }
+
+  protected override ask(prompt: string): Promise<string | null> {
+    this.prompts.push(prompt)
+    return Promise.resolve(this.answers.shift() ?? null)
+  }
+}
+
+class FakeReadline extends EventEmitter {
+  readonly prompts: string[] = []
+  private currentPrompt = ''
+
+  setPrompt(prompt: string): void {
+    this.currentPrompt = prompt
+  }
+
+  prompt(): void {
+    this.prompts.push(this.currentPrompt)
+  }
+
+  close(): void {
+    this.emit('close')
+  }
+}
+
+class BufferedTestPrompter extends Prompter {
+  constructor(private readonly fakeReadline: FakeReadline) {
+    super()
+  }
+
+  protected override ensureOpen() {
+    return this.fakeReadline as never
+  }
+}
+
+describe('hasTrailingLineContinuation', () => {
+  it('returns true when a line ends with an unescaped backslash', () => {
+    expect(hasTrailingLineContinuation("curl 'https://example.com' \\")).toBe(true)
+  })
+
+  it('returns false when the trailing backslash is escaped', () => {
+    expect(hasTrailingLineContinuation(String.raw`printf '\\'`)).toBe(false)
+  })
+
+  it('ignores trailing whitespace after the continuation slash', () => {
+    expect(hasTrailingLineContinuation("curl 'https://example.com' \\   ")).toBe(true)
+  })
+})
+
+describe('Prompter.input', () => {
+  const originalIsTTY = Object.getOwnPropertyDescriptor(process.stdin, 'isTTY')
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    Object.defineProperty(process.stdin, 'isTTY', {
+      value: true,
+      configurable: true
+    })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    if (originalIsTTY) {
+      Object.defineProperty(process.stdin, 'isTTY', originalIsTTY)
+      return
+    }
+
+    Object.defineProperty(process.stdin, 'isTTY', {
+      value: undefined,
+      configurable: true
+    })
+  })
+
+  it('collects multi-line input while the current line ends with a continuation slash', async () => {
+    const prompter = new TestPrompter([
+      "curl 'https://example.com' \\",
+      "-H 'accept: application/json' \\",
+      "--data-raw '{\"ok\":true}'"
+    ])
+
+    const value = await prompter.input('cURL command', {
+      continueWhile: hasTrailingLineContinuation
+    })
+
+    expect(value).toBe(
+      [
+        "curl 'https://example.com' \\",
+        "-H 'accept: application/json' \\",
+        "--data-raw '{\"ok\":true}'"
+      ].join('\n')
+    )
+    expect(prompter.prompts).toEqual(['cURL command: ', '... ', '... '])
+  })
+
+  it('throws when stdin closes before any answer is completed', async () => {
+    const prompter = new TestPrompter([null])
+
+    await expect(prompter.input('cURL command')).rejects.toThrow(ValidationError)
+  })
+
+  it('auto-submits a pasted multi-line cURL after input goes idle', async () => {
+    const rl = new FakeReadline()
+    const prompter = new BufferedTestPrompter(rl)
+    const valuePromise = prompter.input('cURL command', {
+      continueWhile: hasTrailingLineContinuation,
+      submitOnIdleMs: 120
+    })
+
+    rl.emit('line', "curl 'https://example.com/api/test' \\")
+    rl.emit('line', "-H 'accept: application/json' \\")
+    rl.emit('line', "--data-raw '{\"ok\":true}'")
+
+    let settled = false
+    valuePromise.then(() => {
+      settled = true
+    })
+
+    await vi.advanceTimersByTimeAsync(119)
+    expect(settled).toBe(false)
+
+    await vi.advanceTimersByTimeAsync(1)
+
+    await expect(valuePromise).resolves.toBe(
+      [
+        "curl 'https://example.com/api/test' \\",
+        "-H 'accept: application/json' \\",
+        "--data-raw '{\"ok\":true}'"
+      ].join('\n')
+    )
+    expect(rl.prompts).toEqual(['cURL command: ', '... ', '... '])
+  })
+})

--- a/packages/cli/src/api-client.ts
+++ b/packages/cli/src/api-client.ts
@@ -8,7 +8,9 @@ import type {
   CommentResponse,
   DeleteResponse,
   MembersResponse,
-  CreateProjectInput
+  CreateProjectInput,
+  ParseCurlResponse,
+  CreateIssuePayload
 } from './types.js'
 import {
   DEFAULT_PAGE_SIZE,
@@ -249,5 +251,19 @@ export class CurlTicketClient {
         method: 'DELETE'
       }
     )
+  }
+
+  async parseCurl(curl: string): Promise<ParseCurlResponse> {
+    return this.request<ParseCurlResponse>('/api/curl/parse', {
+      method: 'POST',
+      body: JSON.stringify({ curl })
+    })
+  }
+
+  async createIssue(projectId: string, data: CreateIssuePayload): Promise<IssueResponse> {
+    return this.request<IssueResponse>(`/api/projects/${projectId}/issues`, {
+      method: 'POST',
+      body: JSON.stringify(data)
+    })
   }
 }

--- a/packages/cli/src/commands/create-issue.ts
+++ b/packages/cli/src/commands/create-issue.ts
@@ -7,8 +7,7 @@ import {
   normalizeType,
   normalizeStatus,
   normalizeEnvironment,
-  Prompter,
-  hasTrailingLineContinuation
+  Prompter
 } from '../utils.js'
 
 interface CreateIssueOptions {
@@ -43,11 +42,10 @@ async function apiBugFlow(
     if (!prompter) {
       throw new ValidationError('--curl is required for api_bug type')
     }
-    curl = await prompter.input('cURL command', {
-      validate: (v) => (v ? null : 'cURL command cannot be empty.'),
-      continueWhile: hasTrailingLineContinuation,
-      submitOnIdleMs: 120
-    })
+    curl = await prompter.editor('Paste cURL command')
+    if (!curl) {
+      throw new ValidationError('cURL command cannot be empty.')
+    }
   }
 
   const parsed = await client.parseCurl(curl)
@@ -56,6 +54,14 @@ async function apiBugFlow(
   const autoTitle = `${method} ${extractUrlPath(url)}`.slice(0, TITLE_MAX_LENGTH)
   const title = options.title ?? autoTitle
   const environment = options.env ? normalizeEnvironment(options.env) : Environment.Dev
+
+  let description = options.description
+  if (!description && prompter) {
+    const addDesc = await prompter.confirm('Add description?')
+    if (addDesc) {
+      description = await prompter.editor('Description (Markdown supported)')
+    }
+  }
 
   const input: CreateIssuePayload = {
     issueType: 'api_bug',
@@ -66,7 +72,7 @@ async function apiBugFlow(
     environment,
     requestHeaders: headers,
     requestBody: body,
-    ...(options.description && { description: options.description }),
+    ...(description && { description }),
     ...(status && { status })
   }
 
@@ -94,34 +100,22 @@ async function taskFlow(
       validate: (v) => (v ? null : 'Title is required.')
     })
 
-    const action = await prompter.select("What's next?", ['Create now', 'Add details', 'Cancel'])
-
-    if (action === 'Cancel') {
-      process.stderr.write('Cancelled.\n')
-      return
+    const addDesc = await prompter.confirm('Add description?')
+    if (addDesc) {
+      description = await prompter.editor('Description (Markdown supported)')
     }
 
-    if (action === 'Add details') {
-      const why = await prompter.input('Why (motivation)')
-      const goal = await prompter.input('Goal (expected outcome)')
+    process.stderr.write('\n--- Preview ---\n')
+    process.stderr.write(`Title: ${title}\n`)
+    if (description) {
+      process.stderr.write(`Description:\n${description}\n`)
+    }
+    process.stderr.write('--- End Preview ---\n\n')
 
-      const parts: string[] = []
-      if (why) parts.push(`## Why\n${why}`)
-      if (goal) parts.push(`## Goal\n${goal}`)
-      description = parts.join('\n\n')
-
-      process.stderr.write('\n--- Preview ---\n')
-      process.stderr.write(`Title: ${title}\n`)
-      if (description) {
-        process.stderr.write(`Description:\n${description}\n`)
-      }
-      process.stderr.write('--- End Preview ---\n\n')
-
-      const confirmed = await prompter.confirm('Create this issue?')
-      if (!confirmed) {
-        process.stderr.write('Cancelled.\n')
-        return
-      }
+    const confirmed = await prompter.confirm('Create this issue?', true)
+    if (!confirmed) {
+      process.stderr.write('Cancelled.\n')
+      return
     }
   }
 

--- a/packages/cli/src/commands/create-issue.ts
+++ b/packages/cli/src/commands/create-issue.ts
@@ -1,0 +1,178 @@
+import { Environment } from '#shared/constants.js'
+import type { CurlTicketClient } from '../api-client.js'
+import type { CreateIssuePayload, IssueResponse } from '../types.js'
+import {
+  ValidationError,
+  validateProjectId,
+  normalizeType,
+  normalizeStatus,
+  normalizeEnvironment,
+  Prompter,
+  hasTrailingLineContinuation
+} from '../utils.js'
+
+interface CreateIssueOptions {
+  type?: string
+  curl?: string
+  title?: string
+  description?: string
+  env?: string
+  status?: string
+}
+
+const TITLE_MAX_LENGTH = 200
+
+function extractUrlPath(url: string): string {
+  try {
+    return new URL(url).pathname
+  } catch {
+    return url
+  }
+}
+
+async function apiBugFlow(
+  client: CurlTicketClient,
+  projectId: string,
+  options: CreateIssueOptions,
+  status: string | undefined,
+  json: boolean,
+  prompter: Prompter | null
+): Promise<void> {
+  let curl = options.curl
+  if (!curl) {
+    if (!prompter) {
+      throw new ValidationError('--curl is required for api_bug type')
+    }
+    curl = await prompter.input('cURL command', {
+      validate: (v) => (v ? null : 'cURL command cannot be empty.'),
+      continueWhile: hasTrailingLineContinuation,
+      submitOnIdleMs: 120
+    })
+  }
+
+  const parsed = await client.parseCurl(curl)
+  const { method, url, headers, body } = parsed.data
+
+  const autoTitle = `${method} ${extractUrlPath(url)}`.slice(0, TITLE_MAX_LENGTH)
+  const title = options.title ?? autoTitle
+  const environment = options.env ? normalizeEnvironment(options.env) : Environment.Dev
+
+  const input: CreateIssuePayload = {
+    issueType: 'api_bug',
+    title,
+    rawCurl: curl,
+    method,
+    url,
+    environment,
+    requestHeaders: headers,
+    requestBody: body,
+    ...(options.description && { description: options.description }),
+    ...(status && { status })
+  }
+
+  const res = await client.createIssue(projectId, input)
+  printResult(res, json)
+}
+
+async function taskFlow(
+  client: CurlTicketClient,
+  projectId: string,
+  options: CreateIssueOptions,
+  status: string | undefined,
+  json: boolean,
+  prompter: Prompter | null
+): Promise<void> {
+  let title = options.title ?? ''
+  let description = options.description
+
+  if (!options.title) {
+    if (!prompter) {
+      throw new ValidationError('--title is required in non-interactive mode')
+    }
+
+    title = await prompter.input('Title', {
+      validate: (v) => (v ? null : 'Title is required.')
+    })
+
+    const action = await prompter.select("What's next?", ['Create now', 'Add details', 'Cancel'])
+
+    if (action === 'Cancel') {
+      process.stderr.write('Cancelled.\n')
+      return
+    }
+
+    if (action === 'Add details') {
+      const why = await prompter.input('Why (motivation)')
+      const goal = await prompter.input('Goal (expected outcome)')
+
+      const parts: string[] = []
+      if (why) parts.push(`## Why\n${why}`)
+      if (goal) parts.push(`## Goal\n${goal}`)
+      description = parts.join('\n\n')
+
+      process.stderr.write('\n--- Preview ---\n')
+      process.stderr.write(`Title: ${title}\n`)
+      if (description) {
+        process.stderr.write(`Description:\n${description}\n`)
+      }
+      process.stderr.write('--- End Preview ---\n\n')
+
+      const confirmed = await prompter.confirm('Create this issue?')
+      if (!confirmed) {
+        process.stderr.write('Cancelled.\n')
+        return
+      }
+    }
+  }
+
+  const input: CreateIssuePayload = {
+    issueType: 'task',
+    title,
+    ...(description && { description }),
+    ...(status && { status })
+  }
+
+  const res = await client.createIssue(projectId, input)
+  printResult(res, json)
+}
+
+function printResult(res: IssueResponse, json: boolean): void {
+  if (json) {
+    process.stdout.write(JSON.stringify(res, null, 2) + '\n')
+    return
+  }
+  console.log(`Issue created: ${res.friendlyId} — ${res.data.title}`)
+}
+
+export async function createIssueCommand(
+  client: CurlTicketClient,
+  projectId: string,
+  options: CreateIssueOptions,
+  json = false
+): Promise<void> {
+  validateProjectId(projectId)
+
+  const prompter = process.stdin.isTTY ? new Prompter() : null
+  try {
+    let issueType: string
+
+    if (options.type) {
+      issueType = normalizeType(options.type)
+    } else if (prompter) {
+      const selected = await prompter.select('Select issue type', ['API Bug', 'Task'])
+      issueType = selected === 'API Bug' ? 'api_bug' : 'task'
+    } else {
+      throw new ValidationError('--type is required in non-interactive mode')
+    }
+
+    const status = options.status ? normalizeStatus(options.status) : undefined
+
+    if (issueType === 'api_bug') {
+      await apiBugFlow(client, projectId, options, status, json, prompter)
+    } else {
+      await taskFlow(client, projectId, options, status, json, prompter)
+    }
+  } finally {
+    prompter?.close()
+  }
+}

--- a/packages/cli/src/commands/schema.ts
+++ b/packages/cli/src/commands/schema.ts
@@ -126,6 +126,38 @@ export function schemaCommand(): void {
           '--json': { type: 'boolean', description: 'Output raw JSON' }
         }
       },
+      'create-issue': {
+        description: 'Create a new issue',
+        args: [{ name: 'projectId', type: 'uuid', required: true }],
+        options: {
+          '--json': { type: 'boolean', description: 'Output raw JSON' },
+          '-t, --type': {
+            type: 'enum',
+            values: issueTypes,
+            description: 'Issue type (prompted interactively if omitted)'
+          },
+          '--curl': {
+            type: 'string',
+            description: 'Raw cURL command string (required for api_bug)'
+          },
+          '--title': {
+            type: 'string',
+            description: 'Issue title (auto-generated for api_bug from cURL if omitted)'
+          },
+          '--description': { type: 'string', description: 'Issue description (Markdown)' },
+          '--env': {
+            type: 'enum',
+            values: environments,
+            default: 'Dev',
+            description: 'Environment (api_bug only)'
+          },
+          '--status': {
+            type: 'enum',
+            values: [...VALID_STATUS_INPUTS],
+            description: 'Initial issue status'
+          }
+        }
+      },
       'delete-comment': {
         description: 'Delete a comment',
         args: [

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -221,7 +221,10 @@ program
   .option('--curl <curl>', 'Raw cURL command string (required for api_bug)')
   .option('--title <title>', 'Issue title')
   .option('--description <description>', 'Issue description (Markdown)')
-  .option('--env <env>', 'Environment for api_bug only (Local / Dev / Staging / Prod, defaults to Dev)')
+  .option(
+    '--env <env>',
+    'Environment for api_bug only (Local / Dev / Staging / Prod, defaults to Dev)'
+  )
   .option('--status <status>', 'Initial status (Open / in-progress / Done / Close)')
   .action(
     async (
@@ -236,9 +239,7 @@ program
       }
     ) => {
       try {
-        await withAuth((client) =>
-          createIssueCommand(client, projectId, options, isJsonMode())
-        )
+        await withAuth((client) => createIssueCommand(client, projectId, options, isJsonMode()))
       } catch (err) {
         handleError(err, isJsonMode())
       }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -22,6 +22,7 @@ import { projectCommand } from './commands/project.js'
 import { createProjectCommand } from './commands/create-project.js'
 import { membersCommand } from './commands/members.js'
 import { deleteIssueCommand } from './commands/delete-issue.js'
+import { createIssueCommand } from './commands/create-issue.js'
 import { schemaCommand } from './commands/schema.js'
 import { authLoginCommand, authStatusCommand, authLogoutCommand } from './commands/auth.js'
 import { initSkillCommand } from './commands/init-skill/index.js'
@@ -212,6 +213,37 @@ program
       handleError(err, isJsonMode())
     }
   })
+
+program
+  .command('create-issue <projectId>')
+  .description('Create a new issue')
+  .option('-t, --type <type>', 'Issue type (api_bug / task)')
+  .option('--curl <curl>', 'Raw cURL command string (required for api_bug)')
+  .option('--title <title>', 'Issue title')
+  .option('--description <description>', 'Issue description (Markdown)')
+  .option('--env <env>', 'Environment for api_bug only (Local / Dev / Staging / Prod, defaults to Dev)')
+  .option('--status <status>', 'Initial status (Open / in-progress / Done / Close)')
+  .action(
+    async (
+      projectId: string,
+      options: {
+        type?: string
+        curl?: string
+        title?: string
+        description?: string
+        env?: string
+        status?: string
+      }
+    ) => {
+      try {
+        await withAuth((client) =>
+          createIssueCommand(client, projectId, options, isJsonMode())
+        )
+      } catch (err) {
+        handleError(err, isJsonMode())
+      }
+    }
+  )
 
 program
   .command('members <projectId>')

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -122,3 +122,25 @@ export interface CreateProjectInput {
   key: string
   description?: string
 }
+
+export interface ParseCurlResponse {
+  data: {
+    url: string
+    method: string
+    headers: Record<string, string> | null
+    body: unknown | null
+  }
+}
+
+export interface CreateIssuePayload {
+  issueType: string
+  title: string
+  description?: string
+  rawCurl?: string
+  method?: string
+  url?: string
+  environment?: string
+  requestHeaders?: Record<string, string> | null
+  requestBody?: unknown | null
+  status?: string
+}

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -1,15 +1,15 @@
 import { createInterface, type Interface as ReadlineInterface } from 'node:readline'
+import {
+  confirm as inquirerConfirm,
+  editor as inquirerEditor,
+  input as inquirerInput,
+  select as inquirerSelect
+} from '@inquirer/prompts'
 import { IssueStatus, issueTypes, environments, COMMENT_MAX_LENGTH } from '#shared/constants.js'
 import type { IssueType } from '#shared/constants.js'
 
-export function confirm(message: string): Promise<boolean> {
-  const rl = createInterface({ input: process.stdin, output: process.stderr })
-  return new Promise((resolve) => {
-    rl.question(`${message} (y/N): `, (answer: string) => {
-      rl.close()
-      resolve(answer.trim().toLowerCase() === 'y')
-    })
-  })
+export async function confirm(message: string): Promise<boolean> {
+  return inquirerConfirm({ message, default: false })
 }
 
 export class ValidationError extends Error {
@@ -121,11 +121,20 @@ export class Prompter {
     requireTTY()
   }
 
+  /** Temporarily close the readline so @inquirer/prompts can take over stdin. */
+  private pause(): void {
+    this.rl?.close()
+    this.rl = null
+  }
+
   protected ensureOpen(): ReadlineInterface {
     if (this.closed) {
       throw new ValidationError('Prompter is already closed.')
     }
     if (!this.rl) {
+      if (typeof process.stdin.setRawMode === 'function') {
+        process.stdin.setRawMode(false)
+      }
       this.rl = createInterface({ input: process.stdin, output: process.stderr })
       this.rl.once('close', () => {
         this.rl = null
@@ -214,12 +223,17 @@ export class Prompter {
     })
   }
 
-  private async collectInput(question: string, options: PromptInputOptions): Promise<string | null> {
+  private async collectInput(
+    question: string,
+    options: PromptInputOptions
+  ): Promise<string | null> {
     const lines: string[] = []
 
     while (true) {
       const prompt =
-        lines.length === 0 ? `${question}: ` : options.continuationPrompt ?? DEFAULT_CONTINUATION_PROMPT
+        lines.length === 0
+          ? `${question}: `
+          : (options.continuationPrompt ?? DEFAULT_CONTINUATION_PROMPT)
       const answer = await this.ask(prompt)
       if (answer === null) {
         return null
@@ -234,6 +248,18 @@ export class Prompter {
   }
 
   async input(question: string, options: PromptInputOptions = {}): Promise<string> {
+    const needsReadline =
+      options.continueWhile || (options.submitOnIdleMs && options.submitOnIdleMs > 0)
+
+    if (!needsReadline) {
+      this.pause()
+      return inquirerInput({
+        message: question,
+        required: false,
+        validate: options.validate ? (value) => options.validate!(value) ?? true : undefined
+      })
+    }
+
     for (let attempt = 0; attempt < MAX_PROMPT_ATTEMPTS; attempt++) {
       const answer =
         options.submitOnIdleMs && options.submitOnIdleMs > 0
@@ -250,27 +276,23 @@ export class Prompter {
   }
 
   async select(question: string, choices: string[]): Promise<string> {
-    for (let attempt = 0; attempt < MAX_PROMPT_ATTEMPTS; attempt++) {
-      process.stderr.write(`${question}\n`)
-      choices.forEach((choice, i) => {
-        process.stderr.write(`  ${i + 1}) ${choice}\n`)
-      })
-      const answer = await this.ask('Select: ')
-      if (answer === null) {
-        throw new ValidationError('No input available (stdin closed).')
-      }
-      const index = parseInt(answer, 10)
-      if (!Number.isNaN(index) && index >= 1 && index <= choices.length) {
-        return choices[index - 1]
-      }
-      process.stderr.write(`Invalid selection. Enter a number between 1 and ${choices.length}.\n`)
-    }
-    throw new ValidationError(`Too many invalid selections (max ${MAX_PROMPT_ATTEMPTS}).`)
+    this.pause()
+    const result = await inquirerSelect({
+      message: question,
+      choices: choices.map((c) => ({ name: c, value: c }))
+    })
+    return result
   }
 
-  async confirm(message: string): Promise<boolean> {
-    const answer = await this.ask(`${message} (y/N): `)
-    return answer !== null && answer.toLowerCase() === 'y'
+  async editor(message: string): Promise<string> {
+    this.pause()
+    const result = await inquirerEditor({ message, postfix: '.md' })
+    return result.trim()
+  }
+
+  async confirm(message: string, defaultValue = false): Promise<boolean> {
+    this.pause()
+    return inquirerConfirm({ message, default: defaultValue })
   }
 
   close(): void {
@@ -296,6 +318,18 @@ export async function promptInput(
   question: string,
   options: PromptInputOptions = {}
 ): Promise<string> {
+  const needsReadline =
+    options.continueWhile || (options.submitOnIdleMs && options.submitOnIdleMs > 0)
+
+  if (!needsReadline) {
+    requireTTY()
+    return inquirerInput({
+      message: question,
+      required: false,
+      validate: options.validate ? (value) => options.validate!(value) ?? true : undefined
+    })
+  }
+
   const prompter = new Prompter()
   try {
     return await prompter.input(question, options)
@@ -305,10 +339,9 @@ export async function promptInput(
 }
 
 export async function promptSelect(question: string, choices: string[]): Promise<string> {
-  const prompter = new Prompter()
-  try {
-    return await prompter.select(question, choices)
-  } finally {
-    prompter.close()
-  }
+  requireTTY()
+  return inquirerSelect({
+    message: question,
+    choices: choices.map((c) => ({ name: c, value: c }))
+  })
 }

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -1,5 +1,5 @@
-import { createInterface } from 'node:readline'
-import { IssueStatus, issueTypes, COMMENT_MAX_LENGTH } from '#shared/constants.js'
+import { createInterface, type Interface as ReadlineInterface } from 'node:readline'
+import { IssueStatus, issueTypes, environments, COMMENT_MAX_LENGTH } from '#shared/constants.js'
 import type { IssueType } from '#shared/constants.js'
 
 export function confirm(message: string): Promise<boolean> {
@@ -76,4 +76,239 @@ export function normalizeType(type: string): IssueType {
     throw new ValidationError(`Invalid type "${type}". Valid values: ${issueTypes.join(', ')}`)
   }
   return lower as IssueType
+}
+
+export function normalizeEnvironment(env: string): string {
+  const match = environments.find((e) => e.toLowerCase() === env.toLowerCase())
+  if (!match) {
+    throw new ValidationError(
+      `Invalid environment "${env}". Valid values: ${environments.join(', ')}`
+    )
+  }
+  return match
+}
+
+const MAX_PROMPT_ATTEMPTS = 3
+
+function requireTTY(): void {
+  if (!process.stdin.isTTY) {
+    throw new ValidationError('Interactive prompt requires a TTY (stdin is not a terminal).')
+  }
+}
+
+export interface PromptInputOptions {
+  /** Return a non-empty error message to reject the answer and retry (up to MAX_PROMPT_ATTEMPTS). */
+  validate?: (value: string) => string | null
+  /** Continue collecting lines while this returns true for the latest line. */
+  continueWhile?: (value: string, lines: string[]) => boolean
+  /** Prompt shown for follow-up lines when continueWhile keeps the input open. */
+  continuationPrompt?: string
+  /** Auto-submit after this many milliseconds of input idle time. */
+  submitOnIdleMs?: number
+}
+
+const DEFAULT_CONTINUATION_PROMPT = '... '
+
+/**
+ * Holds a single readline interface for the duration of an interactive flow.
+ * Callers should `close()` it in a `finally` block to release stdin.
+ */
+export class Prompter {
+  private rl: ReadlineInterface | null = null
+  private closed = false
+
+  constructor() {
+    requireTTY()
+  }
+
+  protected ensureOpen(): ReadlineInterface {
+    if (this.closed) {
+      throw new ValidationError('Prompter is already closed.')
+    }
+    if (!this.rl) {
+      this.rl = createInterface({ input: process.stdin, output: process.stderr })
+      this.rl.once('close', () => {
+        this.rl = null
+      })
+    }
+    return this.rl
+  }
+
+  protected ask(prompt: string): Promise<string | null> {
+    const rl = this.ensureOpen()
+    return new Promise((resolve) => {
+      let settled = false
+      const onClose = () => {
+        if (settled) return
+        settled = true
+        resolve(null)
+      }
+      rl.once('close', onClose)
+      rl.question(prompt, (ans: string) => {
+        if (settled) return
+        settled = true
+        rl.off('close', onClose)
+        resolve(ans.trim())
+      })
+    })
+  }
+
+  private collectBufferedInput(
+    question: string,
+    options: PromptInputOptions
+  ): Promise<string | null> {
+    const rl = this.ensureOpen()
+    const lines: string[] = []
+    const idleMs = options.submitOnIdleMs ?? 0
+    const continuationPrompt = options.continuationPrompt ?? DEFAULT_CONTINUATION_PROMPT
+
+    return new Promise((resolve) => {
+      let settled = false
+      let idleTimer: NodeJS.Timeout | null = null
+
+      const clearIdleTimer = () => {
+        if (!idleTimer) return
+        clearTimeout(idleTimer)
+        idleTimer = null
+      }
+
+      const cleanup = () => {
+        clearIdleTimer()
+        rl.off('line', onLine)
+        rl.off('close', onClose)
+      }
+
+      const finish = (value: string | null) => {
+        if (settled) return
+        settled = true
+        cleanup()
+        resolve(value)
+      }
+
+      const scheduleFinish = () => {
+        clearIdleTimer()
+        idleTimer = setTimeout(() => {
+          finish(lines.join('\n'))
+        }, idleMs)
+      }
+
+      const onClose = () => finish(null)
+
+      const onLine = (answer: string) => {
+        const normalized = answer.trim()
+        lines.push(normalized)
+
+        if (options.continueWhile?.(normalized, lines)) {
+          rl.setPrompt(continuationPrompt)
+          rl.prompt()
+          return
+        }
+
+        scheduleFinish()
+      }
+
+      rl.on('line', onLine)
+      rl.once('close', onClose)
+      rl.setPrompt(`${question}: `)
+      rl.prompt()
+    })
+  }
+
+  private async collectInput(question: string, options: PromptInputOptions): Promise<string | null> {
+    const lines: string[] = []
+
+    while (true) {
+      const prompt =
+        lines.length === 0 ? `${question}: ` : options.continuationPrompt ?? DEFAULT_CONTINUATION_PROMPT
+      const answer = await this.ask(prompt)
+      if (answer === null) {
+        return null
+      }
+
+      lines.push(answer)
+
+      if (!options.continueWhile?.(answer, lines)) {
+        return lines.join('\n')
+      }
+    }
+  }
+
+  async input(question: string, options: PromptInputOptions = {}): Promise<string> {
+    for (let attempt = 0; attempt < MAX_PROMPT_ATTEMPTS; attempt++) {
+      const answer =
+        options.submitOnIdleMs && options.submitOnIdleMs > 0
+          ? await this.collectBufferedInput(question, options)
+          : await this.collectInput(question, options)
+      if (answer === null) {
+        throw new ValidationError('No input available (stdin closed).')
+      }
+      const errorMsg = options.validate?.(answer)
+      if (!errorMsg) return answer
+      process.stderr.write(`${errorMsg}\n`)
+    }
+    throw new ValidationError(`Too many invalid inputs (max ${MAX_PROMPT_ATTEMPTS}).`)
+  }
+
+  async select(question: string, choices: string[]): Promise<string> {
+    for (let attempt = 0; attempt < MAX_PROMPT_ATTEMPTS; attempt++) {
+      process.stderr.write(`${question}\n`)
+      choices.forEach((choice, i) => {
+        process.stderr.write(`  ${i + 1}) ${choice}\n`)
+      })
+      const answer = await this.ask('Select: ')
+      if (answer === null) {
+        throw new ValidationError('No input available (stdin closed).')
+      }
+      const index = parseInt(answer, 10)
+      if (!Number.isNaN(index) && index >= 1 && index <= choices.length) {
+        return choices[index - 1]
+      }
+      process.stderr.write(`Invalid selection. Enter a number between 1 and ${choices.length}.\n`)
+    }
+    throw new ValidationError(`Too many invalid selections (max ${MAX_PROMPT_ATTEMPTS}).`)
+  }
+
+  async confirm(message: string): Promise<boolean> {
+    const answer = await this.ask(`${message} (y/N): `)
+    return answer !== null && answer.toLowerCase() === 'y'
+  }
+
+  close(): void {
+    if (this.closed) return
+    this.closed = true
+    this.rl?.close()
+    this.rl = null
+  }
+}
+
+export function hasTrailingLineContinuation(value: string): boolean {
+  const trimmed = value.trimEnd()
+  let trailingSlashCount = 0
+
+  for (let index = trimmed.length - 1; index >= 0 && trimmed[index] === '\\'; index--) {
+    trailingSlashCount += 1
+  }
+
+  return trailingSlashCount % 2 === 1
+}
+
+export async function promptInput(
+  question: string,
+  options: PromptInputOptions = {}
+): Promise<string> {
+  const prompter = new Prompter()
+  try {
+    return await prompter.input(question, options)
+  } finally {
+    prompter.close()
+  }
+}
+
+export async function promptSelect(question: string, choices: string[]): Promise<string> {
+  const prompter = new Prompter()
+  try {
+    return await prompter.select(question, choices)
+  } finally {
+    prompter.close()
+  }
 }

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -11,7 +11,7 @@
     "outDir": "dist",
     "declaration": false,
     "sourceMap": true,
-    "baseUrl": ".",
+    "types": ["node"],
     "paths": {
       "#shared/*": ["../../shared/*"]
     }


### PR DESCRIPTION
## Summary

- Add `ct create-issue <projectId>` command supporting API Bug (with `--curl` for server-side cURL parsing) and Task (with `--title`) issue types
- Migrate interactive prompts from readline to `@inquirer/prompts` for arrow-key select, interactive confirm, and editor-based multiline Markdown input (cURL and description)
- Archive the OpenSpec change artifacts for the cli-create-issue feature

## Type of Change

- [x] feat: new feature
- [ ] fix: bug fix
- [x] refactor: code restructuring (no behavior change)
- [ ] chore: maintenance, CI, deps
- [ ] docs: documentation only

## Related Issues

## Test Plan

- [x] Tested locally
- [x] Lint passes (`pnpm lint`)
- [x] Typecheck passes (`pnpm typecheck`)
- [x] Unit tests pass (62 tests, including 10 interactive flow tests)