### PR TITLE
feat(cli): add create-task skill and render issue descriptions as markdown

### DIFF
--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -1,5 +1,6 @@
 @import 'tailwindcss';
 @import '@nuxt/ui';
+@plugin '@tailwindcss/typography';
 
 @theme static {
   --font-sans: 'Public Sans', sans-serif;

--- a/app/components/IssueDescriptionCard.vue
+++ b/app/components/IssueDescriptionCard.vue
@@ -1,0 +1,29 @@
+<script setup lang="ts">
+defineProps<{
+  description: string | null | undefined
+}>()
+
+const { t } = useI18n()
+</script>
+
+<template>
+  <div
+    class="rounded-xl border border-slate-200/70 bg-white p-6 dark:border-slate-800/70 dark:bg-slate-900/50"
+  >
+    <h3
+      class="mb-3 text-xs font-semibold tracking-wider text-slate-500 uppercase dark:text-slate-400"
+    >
+      {{ t('issues.description') }}
+    </h3>
+    <MarkdownRenderer
+      v-if="description && description.trim()"
+      :source="description"
+    />
+    <p
+      v-else
+      class="text-sm text-slate-400 italic dark:text-slate-500"
+    >
+      {{ t('common.noDescription') }}
+    </p>
+  </div>
+</template>

--- a/app/components/MarkdownRenderer.vue
+++ b/app/components/MarkdownRenderer.vue
@@ -1,0 +1,48 @@
+<script setup lang="ts">
+import MarkdownIt from 'markdown-it'
+import DOMPurify from 'isomorphic-dompurify'
+
+const props = defineProps<{
+  source: string | null | undefined
+}>()
+
+const md = new MarkdownIt({
+  html: false,
+  linkify: true,
+  breaks: true
+})
+
+const ALLOWED_PROTOCOL = /^(https?:|mailto:|\/)/i
+
+md.validateLink = (url: string) => ALLOWED_PROTOCOL.test(url.trim())
+
+const defaultLinkOpen =
+  md.renderer.rules.link_open ||
+  ((tokens, idx, options, _env, self) => self.renderToken(tokens, idx, options))
+
+md.renderer.rules.link_open = (tokens, idx, options, env, self) => {
+  const token = tokens[idx]
+  if (token) {
+    const href = token.attrGet('href') || ''
+    if (/^https?:\/\//i.test(href)) {
+      token.attrSet('target', '_blank')
+      token.attrSet('rel', 'noopener noreferrer')
+    }
+  }
+  return defaultLinkOpen(tokens, idx, options, env, self)
+}
+
+const html = computed(() => {
+  const raw = props.source?.trim()
+  if (!raw) return ''
+  return DOMPurify.sanitize(md.render(raw))
+})
+</script>
+
+<template>
+  <div
+    v-if="html"
+    class="prose prose-sm dark:prose-invert max-w-none"
+    v-html="html"
+  />
+</template>

--- a/app/components/MarkdownRenderer.vue
+++ b/app/components/MarkdownRenderer.vue
@@ -1,42 +1,11 @@
 <script setup lang="ts">
-import MarkdownIt from 'markdown-it'
-import DOMPurify from 'isomorphic-dompurify'
+import { renderMarkdown } from '~/utils/markdown'
 
 const props = defineProps<{
   source: string | null | undefined
 }>()
 
-const md = new MarkdownIt({
-  html: false,
-  linkify: true,
-  breaks: true
-})
-
-const ALLOWED_PROTOCOL = /^(https?:|mailto:|\/)/i
-
-md.validateLink = (url: string) => ALLOWED_PROTOCOL.test(url.trim())
-
-const defaultLinkOpen =
-  md.renderer.rules.link_open ||
-  ((tokens, idx, options, _env, self) => self.renderToken(tokens, idx, options))
-
-md.renderer.rules.link_open = (tokens, idx, options, env, self) => {
-  const token = tokens[idx]
-  if (token) {
-    const href = token.attrGet('href') || ''
-    if (/^https?:\/\//i.test(href)) {
-      token.attrSet('target', '_blank')
-      token.attrSet('rel', 'noopener noreferrer')
-    }
-  }
-  return defaultLinkOpen(tokens, idx, options, env, self)
-}
-
-const html = computed(() => {
-  const raw = props.source?.trim()
-  if (!raw) return ''
-  return DOMPurify.sanitize(md.render(raw))
-})
+const html = computed(() => renderMarkdown(props.source))
 </script>
 
 <template>

--- a/app/pages/projects/[id]/issues/[issueId]/index.vue
+++ b/app/pages/projects/[id]/issues/[issueId]/index.vue
@@ -326,12 +326,11 @@ async function updateIssueStatus(nextStatus: IssueStatus) {
         <div class="grid grid-cols-1 gap-6 lg:grid-cols-3">
           <!-- Left Column -->
           <div class="space-y-6 lg:col-span-2">
-            <!-- API Bug: Description Card -->
-            <template v-if="isApiBug">
-              <IssueDescriptionCard :description="issue.description" />
-            </template>
+            <IssueDescriptionCard
+              v-if="isApiBug || isTask"
+              :description="issue.description"
+            />
 
-            <!-- API Bug: Method + URL Row -->
             <template v-if="isApiBug && issue.method && issue.url">
               <div
                 class="flex flex-wrap items-center gap-3 rounded-xl border border-slate-200/70 bg-white p-4 dark:border-slate-800/70 dark:bg-slate-900/50"
@@ -505,11 +504,6 @@ async function updateIssueStatus(nextStatus: IssueStatus) {
                   </div>
                 </template>
               </UTabs>
-            </template>
-
-            <!-- Task: Description card -->
-            <template v-if="isTask">
-              <IssueDescriptionCard :description="issue.description" />
             </template>
 
             <!-- Comments Section -->

--- a/app/pages/projects/[id]/issues/[issueId]/index.vue
+++ b/app/pages/projects/[id]/issues/[issueId]/index.vue
@@ -286,12 +286,6 @@ async function updateIssueStatus(nextStatus: IssueStatus) {
               >
                 {{ issue.title }}
               </h1>
-              <p
-                v-if="issue.description"
-                class="max-w-2xl text-sm leading-relaxed whitespace-pre-wrap text-slate-600 dark:text-slate-300"
-              >
-                {{ issue.description }}
-              </p>
             </div>
             <div class="flex shrink-0 items-center gap-3">
               <USelect
@@ -332,6 +326,11 @@ async function updateIssueStatus(nextStatus: IssueStatus) {
         <div class="grid grid-cols-1 gap-6 lg:grid-cols-3">
           <!-- Left Column -->
           <div class="space-y-6 lg:col-span-2">
+            <!-- API Bug: Description Card -->
+            <template v-if="isApiBug">
+              <IssueDescriptionCard :description="issue.description" />
+            </template>
+
             <!-- API Bug: Method + URL Row -->
             <template v-if="isApiBug && issue.method && issue.url">
               <div
@@ -508,29 +507,9 @@ async function updateIssueStatus(nextStatus: IssueStatus) {
               </UTabs>
             </template>
 
-            <!-- Task: Description prominently displayed -->
+            <!-- Task: Description card -->
             <template v-if="isTask">
-              <div
-                class="rounded-xl border border-slate-200/70 bg-white p-6 dark:border-slate-800/70 dark:bg-slate-900/50"
-              >
-                <h3
-                  class="mb-3 text-xs font-semibold tracking-wider text-slate-500 uppercase dark:text-slate-400"
-                >
-                  {{ $t('issues.description') }}
-                </h3>
-                <p
-                  v-if="issue.description"
-                  class="text-sm leading-relaxed whitespace-pre-wrap text-slate-700 dark:text-slate-300"
-                >
-                  {{ issue.description }}
-                </p>
-                <p
-                  v-else
-                  class="text-sm text-slate-400 italic dark:text-slate-500"
-                >
-                  {{ $t('common.noDescription') }}
-                </p>
-              </div>
+              <IssueDescriptionCard :description="issue.description" />
             </template>
 
             <!-- Comments Section -->

--- a/app/utils/markdown.ts
+++ b/app/utils/markdown.ts
@@ -1,0 +1,28 @@
+import MarkdownIt from 'markdown-it'
+import DOMPurify from 'isomorphic-dompurify'
+
+const ALLOWED_PROTOCOL = /^(https?:|mailto:|\/)/i
+const HTTP_LINK = /^https?:\/\//i
+
+const md = new MarkdownIt({ html: false, linkify: true, breaks: true })
+
+md.validateLink = (url: string) => ALLOWED_PROTOCOL.test(url.trim())
+
+const defaultLinkOpen =
+  md.renderer.rules.link_open ||
+  ((tokens, idx, options, _env, self) => self.renderToken(tokens, idx, options))
+
+md.renderer.rules.link_open = (tokens, idx, options, env, self) => {
+  const token = tokens[idx]
+  if (token && HTTP_LINK.test(token.attrGet('href') || '')) {
+    token.attrSet('target', '_blank')
+    token.attrSet('rel', 'noopener noreferrer')
+  }
+  return defaultLinkOpen(tokens, idx, options, env, self)
+}
+
+export function renderMarkdown(source: string | null | undefined): string {
+  const raw = source?.trim()
+  if (!raw) return ''
+  return DOMPurify.sanitize(md.render(raw))
+}

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -3,7 +3,7 @@ pre-commit:
   jobs:
     - name: format
       glob: '*.{ts,tsx,js,jsx,mjs,cjs,vue,json,jsonc,md}'
-      run: pnpm exec oxfmt {staged_files}
+      run: pnpm exec oxfmt --no-error-on-unmatched-pattern {staged_files}
       stage_fixed: true
 
     - name: lint

--- a/openspec/changes/archive/2026-04-29-add-create-task-skill/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-29-add-create-task-skill/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-29

--- a/openspec/changes/archive/2026-04-29-add-create-task-skill/design.md
+++ b/openspec/changes/archive/2026-04-29-add-create-task-skill/design.md
@@ -1,0 +1,168 @@
+## Context
+
+`packages/cli/` 已透過 `init-skill` 安裝一支 `curl-ticket-issue-analyzer` SKILL.md，該 Skill 是純 Markdown 指令文件，不含程式碼，靠 Claude Code 等 host 解讀並驅動 CLI。本次新增 `curl-ticket-create-task` 採用相同形態：**沒有任何 TS 邏輯落在 CLI runtime**，純粹靠 SKILL.md 描述對話流程，並重用既有 `projects` / `members` / `create-issue` 三個 CLI 子指令。
+
+`init-skill` 目前位於 `packages/cli/src/commands/init-skill/`，內含 `agents.ts`、`file-ops.ts`、`prompts.ts`、`transform.ts`、`index.ts`。從目錄結構推斷它已預期會處理多個 agent/skill；本次只需把新 skill 納入安裝清單即可，不應重構既有抽象。
+
+## Goals / Non-Goals
+
+**Goals:**
+- 提供結構化（Why / Acceptance Criteria）且摩擦最低的「建立 Task」流程
+- 與 `curl-ticket-issue-analyzer` 共存，職責清楚分離（一支讀/分析、一支寫）
+- 沿用 `--json` 輸出與 exit code 慣例，錯誤處理一致
+- 隨 `init-skill` 安裝，無須使用者手動 copy 檔案
+
+**Non-Goals:**
+- 不處理 `api_bug`（cURL 解析流程已由其他 Skill / UI 涵蓋）
+- 不在 CLI runtime 加 `--interactive` 模式
+- 不修改 `create-issue` 指令的旗標、行為、輸出格式
+- 不引入新的 CLI 依賴（不用 `inquirer` 等套件，互動全靠 host 的 AskUserQuestion）
+
+## Decisions
+
+### D1. Skill 與 CLI `--interactive` 並存
+
+選擇：**雙軌並存**——Skill（host-driven，使用 `AskUserQuestion`）與 `curl-ticket create-issue --interactive`（CLI-driven，使用 `@inquirer/prompts`）同時提供，共用同一份 description 樣板與欄位驗證規則。
+
+理由：
+- 兩種使用情境真實存在：在 Claude Code 內希望「自然語言對話」、在純 terminal 希望「不離開 shell」
+- `@inquirer/prompts` 已是 CLI 既有 dependency（`packages/cli/package.json`），不引入新套件
+- 共用樣板（D3）與 assignee 解析（D2 step 5）可避免雙軌行為漂移
+- Skill 不被 `tsup` 編進 dist，純檔案 copy；`--interactive` 只是 `create-issue.ts` 內多一條分支
+
+雙軌一致性如何保證：
+- Description 樣板放在 `packages/cli/src/templates/task.md`，**Skill 與 CLI 都引用同一份**（Skill 在 SKILL.md 內 inline 一份摘要 + 指向 CLI 樣板路徑）
+- 欄位驗證規則寫成 `packages/cli/src/commands/create-issue/validators.ts`，`--interactive` 直接 import；Skill 的對等規則寫進 SKILL.md，並在註解標註「對應 validators.ts」
+- 任一邊新增必填欄位時，PR 必須同時更新兩處（在 PR template 不額外加，靠 spec 與 review 把關）
+
+### D1a. `--interactive` 與既有旗標的互動
+
+`create-issue` 既有旗標：`--type`、`--curl`、`--title`、`--description`、`--assignee`、`--json`、`--dry-run`（若有）。
+
+規則：
+- `--interactive` 只在 `--type task` 下啟用（v1）；搭配 `--type api_bug` 直接報錯，建議使用者用既有旗標或 Skill 的 cURL 流程
+- 使用者若同時帶 `--title` / `--description` / `--assignee`：以這些值為**預設答案**，互動仍會逐題詢問（pre-fill 模式），方便 retry
+- `--from-template <name>` 與 `--description` 互斥；同時出現報錯
+- `--interactive` 不支援 `--json`（互動模式輸出給人看）；同時帶兩個旗標報錯
+- 互動完成後仍走原本的 `createIssue()` API client function，**不複寫 mutation 邏輯**
+
+### D1b. Mode Detection（Step-by-step vs Fast Path）
+
+Skill 支援兩種輸入模式，**由規則決策樹決定**，不交給 LLM 自由判斷：
+
+**Layer 1 — 明確關鍵字覆寫**
+- Force Fast Path：`from this PRD`、`parse this`、`依這份`、`根據以下`、`直接建`、`skip questions`
+- Force Step-by-step：`step by step`、`one by one`、`逐題`、`問我`
+
+**Layer 2 — 結構訊號**（無關鍵字時）
+- Step-by-step：訊息僅含觸發句（≤ 2 行），無 Markdown 結構
+- Fast Path 候選：≥ 3 行 **或** 含 Markdown heading / bullet list / requirement ID 模式 `[A-Z]+-\d+(\.\d+)*`
+
+**Layer 3 — 欄位可抽取性**（Fast Path 候選才執行）
+抽取規則：
+- `title`：第一個 `#` / `##` heading；否則第一句話（截斷至 200 字）
+- `why`：`## Why` / `## Background` / `## 動機` / `## 為什麼` 段落；否則第一段非 heading 文字
+- `acceptance_criteria`：`## Acceptance` / `## AC` / `## Done` / `## 驗收` / `## Requirements` 段落；否則文中第一個 bullet list
+- `references`（選用）：掃描全文收集 `[A-Z]+-\d+(\.\d+)*` 出現的 ID
+
+判定：
+- 三欄位（title / why / AC）全抽到 → **Fast Path**
+- 部分抽到 → `AskUserQuestion` 一次：「使用 auto-derived 值還是逐題？」
+- title 或 why 抽不到 → 退回 **Step-by-step**，把貼上的文字作為每題 hint
+
+**Project 與 Assignee 永遠不會 auto-derive**，除非：
+- Project：`curl-ticket projects --json` 只回 1 個；或文字明確含 project key 且能對到清單
+- Assignee：文字含 `@<name>` 或 `assign to <name>` 模式
+
+理由：Fast Path 與 Step-by-step 的 mutation 路徑相同，差別只在欄位填入方式；Preview gate 是兩者共用的最終護欄，所以 Mode Detection 即使誤判也不會造成錯誤的 mutation。寫死規則而非交給 LLM 自由判斷，確保兩個 host（Claude Code / Codex）行為一致、可寫成 spec scenario 可驗證。
+
+### D2. 問答順序與欄位
+
+固定 5 步，**逐題**用 `AskUserQuestion`：
+
+1. **Project**：先 `curl-ticket projects --json`。若 0 個 → 終止並提示先建 project；1 個 → 直接採用、跳過此題；≥2 個 → 以 `name (KEY)` 為 option、`projectId` 為 value，open-ended 允許貼 ID。
+2. **Title**：open-ended，必填，trim 後長度 1–200（與 `createIssueSchema` 對齊）。
+3. **Why**：open-ended，建議 1–3 句，允許空字串但不建議。
+4. **Acceptance Criteria**：open-ended，提示「每行一條，- 開頭可省略」；Skill 端負責正規化成 bullet list。
+5. **Assignee**：open-ended，預設 `me`。輸入 `none` / `null` → 不指派；輸入 email/uuid → 直接帶入；輸入名字 → 走 `curl-ticket members <projectId> --json`，比對 `name`（fallback email local-part），多筆則回頭問使用者選擇。
+
+理由：問題順序按「定位 → 內容 → 指派」由廣到細；Why/AC 拆兩題比一次塞長表單更穩定，AC 結構化也方便日後 Done-criteria 驗收。
+
+### D3. Description 樣板與 `--from-template`
+
+樣板存放：`packages/cli/src/templates/<name>.md`，v1 只提供 `task.md`：
+
+```
+## Why
+{{why}}
+
+## Acceptance Criteria
+{{acceptance_criteria}}
+
+## Notes
+{{notes}}
+```
+
+`{{var}}` 是純文字 placeholder（不引入 templating 套件，自寫 `String#replaceAll`）。空值處理：
+- `why` 留空 → 替換成 `_(not provided)_`
+- `acceptance_criteria` 留空 → 整個 section（heading + body）連同前一個 blank line 移除
+- `notes` 留空 → 同上移除
+
+`--from-template <name>` 行為：
+- 不帶 `--interactive`：印出已替換 placeholder 為空的樣板字串到 stdout，使用者可重導向到檔案再用 `--description "$(cat ...)"`；或直接寫成 `--description` 的預設值（取決於 `--print-only` 旗標，v1 採前者，避免破壞既有單機呼叫）
+- 帶 `--interactive`：把樣板內容拆解到對應問題作為預設答案
+
+對齊：Skill 在 SKILL.md 內 inline 同樣的樣板字串並標註「source of truth: `packages/cli/src/templates/task.md`」，避免 host 解析失敗時還能 fallback。
+
+理由：與 `curl-ticket-issue-analyzer` 既有 SKILL.md 範例 (`--description "## Why\n..."`) 對齊；站台 issue 詳情頁已支援 Markdown 渲染；單一檔案來源讓 Skill / CLI / 人手三條路徑都看同一份。
+
+### D4. Preview / Confirm gate
+
+送出前用 `AskUserQuestion` 顯示組好的 title + description preview，三個選項：`Confirm` / `Edit` / `Cancel`。`Edit` 退回詢問要改哪一欄，重新流程；`Cancel` 直接結束、不呼叫 CLI。
+
+Fast Path 路徑下，Preview **必須**標註資料來源，例如：
+
+```
+[Auto-derived from your message]
+Title: <抽到的標題>
+---
+<rendered description>
+---
+Project: <name> (<key>)
+Assignee: <resolved>
+```
+
+理由：建立 Task 是 mutation，且 `create-issue` 沒有 `--dry-run`（目前只有 `update-status` 與 `assign` 支援），由 Skill 層補一道確認最便宜。Fast Path 把 Preview 從「最後確認」升格為「Mode Detection 的安全網」，標註來源讓使用者一眼看出哪些是 Agent 推導的。
+
+### D5. `init-skill` 安裝策略
+
+把新 skill 加入既有清單，沿用目前 prompt（互動式選 / 全選），**不**自動覆寫使用者既有檔案；若目的地已存在，提示 overwrite/skip。
+
+理由：保留使用者可能的客製化；行為與多數 scaffolder 一致。
+
+## Risks / Trade-offs
+
+- **[Host 相依]** Skill 仰賴 host 提供 `AskUserQuestion`。非 Claude Code 環境（純 CLI）跑不起來 → Mitigation: SKILL.md 標註「需 AI host」，並在 README 同步說明；未來若要支援，再導入 D1 替代方案。
+- **[名字解析歧義]** 同名 member 多筆時需 round-trip 給使用者選擇，會中斷流程 → Mitigation: members 列表先排序、顯示 email，並在 SKILL.md 明示處理流程（已沿用 `curl-ticket-issue-analyzer` 的規則）。
+- **[Schema drift]** 未來 `createIssueSchema` 若新增必填欄位，Skill 不會自動跟上 → Mitigation: SKILL.md 開頭沿用「先跑 `curl-ticket schema`」慣例；長期可在 CLI 暴露 `create-issue --print-required-fields` 之類，但本次不做。
+- **[Token 消耗]** members 列表大時會吃 context → Mitigation: `--json` 已是最精簡輸出；如未來成痛點，再考慮 CLI 加 `--search <query>`。
+- **[雙軌漂移]** Skill 與 `--interactive` 同步維護成本 → Mitigation: 樣板 (`templates/task.md`) 與驗證 (`validators.ts`) 單一檔案來源；spec scenario 同時涵蓋兩條路徑，CI typecheck/lint 抓掉一邊忘改的問題。
+- **[`--interactive` 與 `--json` 衝突]** 互動輸出非結構化會破壞 agent 用法 → Mitigation: 同時帶兩旗標即報錯（exit code 4）。
+
+## Migration Plan
+
+無資料遷移。發佈步驟：
+
+1. 在 feature branch 完成檔案新增 + `init-skill` 更新
+2. 合併到 main 後，`packages/cli` 跑 `npm version minor`（新增功能屬 minor）
+3. push tag `cli@x.y.z`，CI 自動發佈到 npm
+4. 既有使用者執行 `curl-ticket init-skill` 即可取得新 skill；舊 skill 不受影響
+
+回滾：若發現問題，下一個 patch 版本將 init-skill 清單中的 `curl-ticket-create-task` 拿掉，並從 `packages/cli/skills/` 刪除目錄；npm 不 unpublish。
+
+## Open Questions
+
+1. 是否在 `init-skill` 提供「全部安裝」與「逐支選擇」兩種模式？依現有 `prompts.ts` 行為決定，實作時對齊現況即可。
+2. SKILL.md 的撰寫語言：與 `curl-ticket-issue-analyzer` 一致採英文，僅在 user-facing 提示上保留中英雙語？傾向**全英**保持 host 解析穩定，問答中若使用者用中文，host 自然會以中文回覆。
+3. `--from-template` 不帶 `--interactive` 時的輸出：v1 採「印到 stdout」方便 `$(...)` 重導向；若實測使用者更常想 `> file.md` 編輯後再貼，未必需要改設計，但要在 README 範例呈現。
+4. 是否要讓 `templates/` 支援使用者自訂（讀 `~/.config/curl-ticket/templates/`）？v1 不做，先看內建樣板的反饋。

--- a/openspec/changes/archive/2026-04-29-add-create-task-skill/proposal.md
+++ b/openspec/changes/archive/2026-04-29-add-create-task-skill/proposal.md
@@ -1,0 +1,47 @@
+## Why
+
+目前 CLI 已支援 `curl-ticket create-issue --type task`，但 end user（與 AI agent）需要自己組裝 title、description Markdown、解析 assignee 等步驟，門檻偏高、輸出品質也不一致。仿 `openspec-propose` 提供一支互動式 Skill，能引導使用者依固定格式逐題回答後自動建立 Task，可以大幅降低建立 Task 的摩擦並讓內容結構統一（## Why / ## Acceptance Criteria）。
+
+## What Changes
+
+- 新增 Skill `curl-ticket-create-task`，放在 `packages/cli/skills/curl-ticket-create-task/SKILL.md`
+- Skill 支援兩種模式：**Step-by-step** 透過 `AskUserQuestion` 依序詢問 project → title → why → acceptance criteria → assignee；**Fast Path** 從使用者貼上的 PRD / 設計文件文字中自動抽取欄位後直接進入 Preview。模式選擇由 **Mode Detection** 決策樹決定（明確關鍵字 → 訊息結構 → 欄位可抽取性三層判斷）
+- 不論模式，Project（從 `curl-ticket projects --json` 動態載入）與 Assignee（預設 `me`，名字走 `curl-ticket members <projectId> --json` 解析）的解析規則一致
+- 收齊回覆後組裝 Markdown description（含可選 `## References` section，從文字中偵測 `[A-Z]+-\d+` 之類的 requirement ID），顯示 preview，並在使用者確認後呼叫 `curl-ticket create-issue --type task --json` 建立
+- 建立成功後輸出 `friendlyId`（CT-XX）與站台 URL
+- 更新 `packages/cli/src/commands/init-skill/`，使 `curl-ticket init-skill` 一併安裝這支新 Skill
+- **CLI 端優化 1：** `curl-ticket create-issue --interactive` — 用 `@inquirer/prompts`（已是 CLI dependency）內建相同 5 步問答，讓沒有 AI host 的使用者也能在純 terminal 跑完整流程
+- **CLI 端優化 2：** `curl-ticket create-issue --from-template <name>` — 預先 stub description 樣板（task 樣板含 `## Why` / `## Acceptance Criteria` / `## Notes`），讓 Skill 與 `--interactive` 共用同一份樣板，減少漂移
+- 不修改後端 API，也不修改 `create-issue` 既有非互動旗標的行為（純新增旗標）
+
+### Non-goals
+
+- 不支援 `api_bug` 類型的互動模式（本次 `--interactive` 與 Skill 只處理 task）
+- 不改變既有 `curl-ticket-issue-analyzer` Skill 的行為
+- 不新增前端 UI 或後端 endpoint
+
+## Capabilities
+
+### New Capabilities
+
+- `cli-create-task-skill`: 互動式 Skill 規範——觸發條件、問答順序、欄位驗證、description 樣板、preview/確認流程、CLI 指令組裝、錯誤處理（依 CLI exit code）
+- `cli-init-skill-bundle`: `init-skill` 指令安裝多支 skill 的行為（清單、覆寫策略、安裝目的地）
+- `cli-create-issue-interactive`: `curl-ticket create-issue --interactive` 純 CLI 互動模式的問答流程、欄位驗證、preview 確認、與既有非互動旗標的關係
+- `cli-issue-description-template`: `--from-template` 旗標的樣板註冊機制與 task 樣板內容（與 Skill 共用）
+
+### Modified Capabilities
+
+（無——本變更不調整既有 spec 的需求）
+
+## Impact
+
+- 受影響檔案：
+  - `packages/cli/skills/curl-ticket-create-task/SKILL.md`（新增）
+  - `packages/cli/src/commands/init-skill/`（更新安裝清單）
+  - `packages/cli/src/commands/create-issue.ts`（新增 `--interactive`、`--from-template`）
+  - `packages/cli/src/templates/`（新目錄，存放 description 樣板）
+  - `packages/cli/package.json`（`files` 欄位若需新增路徑）
+  - `packages/cli/README.md`（補充新 skill 與旗標說明）
+- PRD 模組：本變更僅涉及 CLI/Skill 工具鏈，不需更新 `docs/prd/auth.md`、`issues.md` 等模組
+- 依賴：無新套件；沿用 `curl-ticket projects | members | create-issue` 既有指令
+- 發佈：透過既有 CLI tag (`cli@x.x.x`) 流程隨下一版 npm publish

--- a/openspec/changes/archive/2026-04-29-add-create-task-skill/specs/cli-create-issue-interactive/spec.md
+++ b/openspec/changes/archive/2026-04-29-add-create-task-skill/specs/cli-create-issue-interactive/spec.md
@@ -1,0 +1,73 @@
+## ADDED Requirements
+
+### Requirement: `--interactive` flag scope
+
+The `curl-ticket create-issue` command SHALL accept an `--interactive` (alias `-i`) flag that, when present with `--type task`, drives a terminal-based question flow using `@inquirer/prompts`.
+
+#### Scenario: Flag enabled for task type
+- **WHEN** the user runs `curl-ticket create-issue <projectId> --type task --interactive`
+- **THEN** the CLI starts an interactive question flow without needing additional flags
+
+#### Scenario: Flag rejected for non-task types
+- **WHEN** the user runs `curl-ticket create-issue <projectId> --type api_bug --interactive`
+- **THEN** the CLI exits with code 4 and a message indicating `--interactive` is only supported with `--type task` in v1
+
+#### Scenario: Flag conflicts with `--json`
+- **WHEN** the user passes both `--interactive` and `--json`
+- **THEN** the CLI exits with code 4 and a message that the two flags are mutually exclusive
+
+### Requirement: Question parity with the skill
+
+The interactive flow SHALL ask the same questions in the same order as the `curl-ticket-create-task` skill: project (skipped if `<projectId>` was already passed), title, why, acceptance criteria, assignee.
+
+#### Scenario: ProjectId argument skips project question
+- **WHEN** a project ID is supplied as a positional argument
+- **THEN** the interactive flow does not ask for a project and uses that ID
+
+#### Scenario: ProjectId omitted triggers picker
+- **WHEN** the user runs `curl-ticket create-issue --type task --interactive` without a project ID
+- **THEN** the CLI fetches projects via the existing API client and presents a picker; if zero projects are returned the CLI exits with code 4
+
+#### Scenario: Acceptance criteria collected as multi-line input
+- **WHEN** the user is prompted for acceptance criteria
+- **THEN** the prompt accepts multiple lines (one criterion per line) and the CLI normalises each non-empty line into a `- <line>` bullet
+
+### Requirement: Pre-fill from non-interactive flags
+
+When `--interactive` is combined with `--title`, `--description`, or `--assignee`, the CLI SHALL use those values as default answers but still ask each question.
+
+#### Scenario: Title pre-filled
+- **WHEN** the user runs `curl-ticket create-issue <projectId> --type task --interactive --title "Fix login"`
+- **THEN** the title prompt is shown with `Fix login` as the default value, which the user can accept by pressing Enter
+
+#### Scenario: Description pre-filled and split into sections
+- **WHEN** the user passes `--description` containing `## Why` and `## Acceptance Criteria` sections
+- **THEN** the CLI parses the Markdown and pre-fills the why and acceptance criteria prompts with the corresponding section bodies
+
+### Requirement: Preview and confirmation
+
+The interactive flow SHALL display the assembled title and description before issuing any mutation, and MUST NOT call the create-issue API until the user confirms.
+
+#### Scenario: Confirm sends the request
+- **WHEN** the user selects `Confirm` at the preview prompt
+- **THEN** the CLI calls the existing create-issue API client with the assembled payload
+
+#### Scenario: Edit returns to a single field
+- **WHEN** the user selects `Edit`
+- **THEN** the CLI shows a follow-up picker (`Title` / `Why` / `Acceptance Criteria` / `Assignee`) and re-runs only the chosen prompt before showing the preview again
+
+#### Scenario: Cancel exits without mutation
+- **WHEN** the user selects `Cancel`
+- **THEN** the CLI exits with code 0 without calling any mutating endpoint and prints a short confirmation message
+
+### Requirement: Result reporting
+
+On success, the interactive flow SHALL print the resulting `friendlyId` and issue URL in human-readable form (not JSON, since `--json` is incompatible).
+
+#### Scenario: Success output
+- **WHEN** the API returns 201 with the created issue
+- **THEN** the CLI prints a line containing the friendly ID (e.g. `CT-42`) and the issue URL
+
+#### Scenario: API error surfaces verbatim
+- **WHEN** the API returns a 4xx error
+- **THEN** the CLI prints the error message and exits with the corresponding mapped exit code (2 for 401/403, 3 for 404, 4 for 422)

--- a/openspec/changes/archive/2026-04-29-add-create-task-skill/specs/cli-create-task-skill/spec.md
+++ b/openspec/changes/archive/2026-04-29-add-create-task-skill/specs/cli-create-task-skill/spec.md
@@ -1,0 +1,145 @@
+## ADDED Requirements
+
+### Requirement: Skill packaging and discovery
+
+The `curl-ticket-create-task` skill SHALL ship as a single `SKILL.md` file under `packages/cli/skills/curl-ticket-create-task/` and MUST be included in the `files` array of `packages/cli/package.json` so it is published to npm.
+
+#### Scenario: Skill file is published with the CLI
+- **WHEN** a user installs `@curl-ticket/cli` from npm
+- **THEN** the installed package contains `skills/curl-ticket-create-task/SKILL.md`
+
+#### Scenario: Skill metadata identifies the trigger
+- **WHEN** a host loads the SKILL.md frontmatter
+- **THEN** the `name` field equals `curl-ticket-create-task` and the `description` field describes triggering on phrases such as "create task", "新增 task", "add task", "open ticket as task"
+
+### Requirement: Mode detection
+
+The skill SHALL classify each invocation into one of two modes — **Step-by-step** or **Fast Path** — using a deterministic three-layer decision tree, before asking any question. Project and assignee SHALL always be re-prompted unless explicitly resolvable from the message.
+
+#### Scenario: Explicit keyword forces Fast Path
+- **WHEN** the trigger message contains any of `from this PRD`, `parse this`, `依這份`, `根據以下`, `直接建`, `skip questions`
+- **THEN** the skill enters Fast Path regardless of structural signals
+
+#### Scenario: Explicit keyword forces Step-by-step
+- **WHEN** the trigger message contains any of `step by step`, `one by one`, `逐題`, `問我`
+- **THEN** the skill enters Step-by-step regardless of structural signals
+
+#### Scenario: Short trigger message defaults to Step-by-step
+- **WHEN** the trigger message is two lines or fewer with no Markdown headings, bullet lists, or `[A-Z]+-\d+` IDs
+- **THEN** the skill enters Step-by-step
+
+#### Scenario: Structured payload becomes a Fast Path candidate
+- **WHEN** the trigger message has three or more lines, OR contains a Markdown heading, bullet list, or a token matching `[A-Z]+-\d+(\.\d+)*`
+- **THEN** the skill becomes a Fast Path candidate and proceeds to extraction
+
+#### Scenario: All three core fields extractable
+- **WHEN** the skill can extract non-empty title, why, and acceptance criteria from the message
+- **THEN** the skill enters Fast Path and skips the per-field prompts for those three fields
+
+#### Scenario: Partial extraction asks user to choose
+- **WHEN** the skill extracts at least one but not all three core fields
+- **THEN** the skill asks the user once via `AskUserQuestion` to choose between `Use auto-derived values` and `Ask me one by one`, and proceeds accordingly
+
+#### Scenario: Title or why missing falls back to Step-by-step
+- **WHEN** the skill cannot extract title or why
+- **THEN** the skill falls back to Step-by-step and surfaces the pasted text as a hint inside each question prompt
+
+#### Scenario: Project and assignee are not auto-derived by default
+- **WHEN** Fast Path is selected
+- **THEN** the skill still resolves project via the existing rules (skip if exactly one project, otherwise prompt) and still prompts for assignee unless the message contains `@<name>` or `assign to <name>`
+
+### Requirement: Interactive question flow
+
+The skill SHALL drive the host (e.g. Claude Code) to ask the user, in order, for: project, title, why, acceptance criteria, assignee. Each question MUST be a separate `AskUserQuestion` invocation.
+
+#### Scenario: Project selection with multiple projects
+- **WHEN** `curl-ticket projects --json` returns two or more projects
+- **THEN** the host presents each project as an option labelled `<name> (<key>)` with the project ID as the value, and accepts a pasted project ID as a free-form fallback
+
+#### Scenario: Project selection with one project
+- **WHEN** `curl-ticket projects --json` returns exactly one project
+- **THEN** the skill skips the project question and uses that project's ID
+
+#### Scenario: Project selection with no projects
+- **WHEN** `curl-ticket projects --json` returns zero projects
+- **THEN** the skill stops and instructs the user to create a project first
+
+#### Scenario: Title is required and bounded
+- **WHEN** the user submits a title
+- **THEN** the skill trims whitespace and rejects empty strings or strings longer than 200 characters, re-asking until valid
+
+#### Scenario: Acceptance criteria normalisation
+- **WHEN** the user enters multiple lines of acceptance criteria
+- **THEN** the skill normalises each non-empty line into a Markdown bullet (`- <line>`), stripping any leading `- ` the user already typed
+
+### Requirement: Assignee resolution
+
+The skill SHALL resolve the assignee using the same rules as `curl-ticket-issue-analyzer`: `me`, `none`/`null`, UUID, email, or natural-language name (case-insensitive match against `curl-ticket members <projectId> --json` on `name`, falling back to email local-part).
+
+#### Scenario: Default assignee is the current user
+- **WHEN** the user submits an empty assignee answer
+- **THEN** the skill passes `--assignee me` to `curl-ticket create-issue`
+
+#### Scenario: Name resolves to a single member
+- **WHEN** the user enters a name that matches exactly one member case-insensitively
+- **THEN** the skill passes that member's email or userId to `--assignee`
+
+#### Scenario: Name matches multiple members
+- **WHEN** the user enters a name that matches two or more members
+- **THEN** the skill lists the candidates with their emails and asks the user to confirm which one to use
+
+#### Scenario: Name matches no member
+- **WHEN** the user enters a name that does not match any member
+- **THEN** the skill reports that no such member exists in the project and re-asks for an assignee
+
+### Requirement: Description Markdown template
+
+The skill SHALL assemble the issue description from a fixed Markdown template containing `## Why`, `## Acceptance Criteria`, and `## Notes` sections, mirroring `packages/cli/src/templates/task.md` so the skill and `--interactive` produce identical output.
+
+#### Scenario: SKILL.md inlines the same structure
+- **WHEN** a developer reads the SKILL.md template section
+- **THEN** the inline Markdown matches the section names and placeholder semantics defined in `cli-issue-description-template`
+
+#### Scenario: Template includes provided sections
+- **WHEN** the user provides a why and at least one acceptance criterion
+- **THEN** the description body matches `## Why\n<why>\n\n## Acceptance Criteria\n- <item>\n...`
+
+#### Scenario: Empty why is preserved structurally
+- **WHEN** the user leaves the why blank
+- **THEN** the description still contains the `## Why` heading with a placeholder line (e.g. `_(not provided)_`)
+
+### Requirement: Preview and confirmation gate
+
+The skill SHALL display a preview of the assembled title and description, and MUST NOT call `curl-ticket create-issue` until the user explicitly confirms.
+
+#### Scenario: Preview is shown before mutation
+- **WHEN** all answers are collected
+- **THEN** the host renders the title and description preview and asks the user to choose `Confirm`, `Edit`, or `Cancel`
+
+#### Scenario: Fast Path preview labels auto-derived fields
+- **WHEN** the skill enters Fast Path or Hybrid (partial extraction accepted)
+- **THEN** the preview includes an `[Auto-derived from your message]` marker before the listed fields, so the user can spot Agent-inferred values
+
+#### Scenario: Edit returns to the relevant question
+- **WHEN** the user picks `Edit`
+- **THEN** the skill asks which field to change and re-runs only that question, then shows a fresh preview
+
+#### Scenario: Cancel aborts without side effects
+- **WHEN** the user picks `Cancel`
+- **THEN** the skill exits without calling any mutating CLI command
+
+### Requirement: CLI invocation and result reporting
+
+On confirm, the skill SHALL invoke `curl-ticket create-issue <projectId> --type task --title <title> --description <markdown> --assignee <resolved> --json` and report the resulting `friendlyId` and issue URL.
+
+#### Scenario: Successful creation
+- **WHEN** the CLI returns exit code 0 with a JSON payload
+- **THEN** the skill outputs the `friendlyId` (e.g. `CT-42`) and the issue URL from the payload
+
+#### Scenario: CLI reports a validation error
+- **WHEN** the CLI returns exit code 4
+- **THEN** the skill surfaces the `message` field, does not retry automatically, and offers to re-edit the inputs
+
+#### Scenario: CLI reports auth or network errors
+- **WHEN** the CLI returns exit code 2 or 5
+- **THEN** the skill surfaces the error message and instructs the user to run `curl-ticket auth` or check connectivity, without retrying

--- a/openspec/changes/archive/2026-04-29-add-create-task-skill/specs/cli-init-skill-bundle/spec.md
+++ b/openspec/changes/archive/2026-04-29-add-create-task-skill/specs/cli-init-skill-bundle/spec.md
@@ -1,0 +1,37 @@
+## ADDED Requirements
+
+### Requirement: Multi-skill installation manifest
+
+The `curl-ticket init-skill` command SHALL maintain an internal manifest of installable skills and MUST include `curl-ticket-create-task` alongside the existing `curl-ticket-issue-analyzer` skill.
+
+#### Scenario: Manifest exposes both skills
+- **WHEN** a user runs `curl-ticket init-skill`
+- **THEN** the command lists `curl-ticket-issue-analyzer` and `curl-ticket-create-task` as available skills
+
+#### Scenario: New skill source path is resolved from the package
+- **WHEN** the install routine reads a skill source
+- **THEN** it resolves the file from `<packageRoot>/skills/<skill-name>/SKILL.md` so it works for both local development and globally installed CLI
+
+### Requirement: Non-destructive overwrite handling
+
+When the destination file for a skill already exists, the install routine SHALL prompt the user before overwriting and MUST default to skipping.
+
+#### Scenario: Destination already exists
+- **WHEN** `<destination>/SKILL.md` exists for a selected skill
+- **THEN** the user is prompted to overwrite or skip, and skipping leaves the existing file unchanged
+
+#### Scenario: Fresh install
+- **WHEN** the destination directory does not exist
+- **THEN** the install routine creates the directory tree and writes the SKILL.md without prompting
+
+### Requirement: Selection UX parity
+
+The `init-skill` command SHALL allow users to install all skills at once or select a subset, using the same interaction pattern already implemented for the existing skill.
+
+#### Scenario: Install all skills
+- **WHEN** the user opts to install all skills
+- **THEN** every skill in the manifest is installed, subject to the overwrite rules above
+
+#### Scenario: Install a subset
+- **WHEN** the user selects only `curl-ticket-create-task`
+- **THEN** only that skill's SKILL.md is written; the analyzer skill is not touched

--- a/openspec/changes/archive/2026-04-29-add-create-task-skill/specs/cli-issue-description-template/spec.md
+++ b/openspec/changes/archive/2026-04-29-add-create-task-skill/specs/cli-issue-description-template/spec.md
@@ -1,0 +1,61 @@
+## ADDED Requirements
+
+### Requirement: Template registry
+
+Description templates SHALL live as Markdown files under `packages/cli/src/templates/<name>.md` and MUST be bundled into the CLI tarball via the `files` field in `packages/cli/package.json`.
+
+#### Scenario: Templates ship with the package
+- **WHEN** a user installs `@curl-ticket/cli` from npm
+- **THEN** the installed package contains `templates/task.md`
+
+#### Scenario: Template lookup is case-sensitive
+- **WHEN** the CLI resolves `--from-template task`
+- **THEN** it loads `templates/task.md` and treats names as case-sensitive (no implicit lowercasing)
+
+### Requirement: Task template content
+
+The `task` template SHALL contain `## Why`, `## Acceptance Criteria`, `## Notes`, and `## References` sections in that order, each with a placeholder body that is substituted at runtime.
+
+#### Scenario: Placeholders documented
+- **WHEN** a developer reads `templates/task.md`
+- **THEN** the file uses `{{why}}`, `{{acceptance_criteria}}`, `{{notes}}`, and `{{references}}` as the only placeholders
+
+#### Scenario: Empty `why` becomes a marker
+- **WHEN** the substituted `why` value is an empty string
+- **THEN** the rendered output replaces `{{why}}` with `_(not provided)_`
+
+#### Scenario: Empty optional sections are dropped
+- **WHEN** the substituted `acceptance_criteria`, `notes`, or `references` value is empty
+- **THEN** the rendered output removes the entire heading and body for that section, including the preceding blank line
+
+#### Scenario: References section receives bullet-list IDs
+- **WHEN** the skill (in Fast Path) extracts requirement IDs matching `[A-Z]+-\d+(\.\d+)*` from the user's message
+- **THEN** each unique ID is rendered as a `- <ID>` bullet under the `## References` section in the order of first appearance
+
+### Requirement: `--from-template` flag
+
+The `curl-ticket create-issue` command SHALL accept a `--from-template <name>` flag that resolves to a registered template and uses it as the description source.
+
+#### Scenario: Print mode without `--interactive`
+- **WHEN** the user runs `curl-ticket create-issue --type task --from-template task`
+- **THEN** the CLI prints the rendered template (with empty placeholders substituted) to stdout and exits with code 0 without calling the API
+
+#### Scenario: Pre-fill mode with `--interactive`
+- **WHEN** the user runs `curl-ticket create-issue --type task --from-template task --interactive`
+- **THEN** the CLI parses the template into the why / acceptance criteria / notes prompts as default answers
+
+#### Scenario: Conflict with `--description`
+- **WHEN** the user passes both `--from-template` and `--description`
+- **THEN** the CLI exits with code 4 and a message that the two flags are mutually exclusive
+
+#### Scenario: Unknown template name
+- **WHEN** the user passes `--from-template unknown`
+- **THEN** the CLI exits with code 4 listing the available template names
+
+### Requirement: Skill alignment
+
+The `curl-ticket-create-task` skill SHALL inline a copy of the task template structure in its SKILL.md and MUST cite `packages/cli/src/templates/task.md` as the source of truth.
+
+#### Scenario: SKILL.md cites the template path
+- **WHEN** a developer reads the skill's description-template section
+- **THEN** the section references `packages/cli/src/templates/task.md` as the canonical source

--- a/openspec/changes/archive/2026-04-29-add-create-task-skill/tasks.md
+++ b/openspec/changes/archive/2026-04-29-add-create-task-skill/tasks.md
@@ -1,0 +1,61 @@
+## 1. Skill 內容
+
+- [x] 1.1 在 `packages/cli/skills/curl-ticket-create-task/` 新增 `SKILL.md`，frontmatter 設定 `name: curl-ticket-create-task` 與觸發描述
+- [x] 1.2 撰寫「First-run introspection」段落，提示先跑 `curl-ticket schema` 與 `curl-ticket projects --json`
+- [x] 1.3 撰寫 5 步問答流程說明（project / title / why / acceptance criteria / assignee），每步明確指示使用 `AskUserQuestion`
+- [x] 1.4 撰寫 assignee 解析規則（me / none / uuid / email / 名字 → members 比對），與 `curl-ticket-issue-analyzer` 規則對齊
+- [x] 1.5 撰寫 description Markdown 樣板（`## Why` + `## Acceptance Criteria`，含空白處理）
+- [x] 1.6 撰寫 Preview / Confirm / Edit / Cancel gate 說明
+- [x] 1.7 撰寫 CLI 呼叫範例與成功輸出（friendlyId、URL）
+- [x] 1.8 撰寫錯誤處理段落，依 exit code 2/3/4/5 給出對應指引
+- [x] 1.9 撰寫 **Mode Detection** 段落：三層決策（明確關鍵字 → 結構訊號 → 欄位可抽取性），含中英關鍵字清單與抽取規則
+- [x] 1.10 撰寫 Fast Path 抽取規則：title / why / acceptance_criteria 段落比對與 fallback；references 收集 `[A-Z]+-\d+(\.\d+)*` ID
+- [x] 1.11 撰寫 Project / Assignee 不被 auto-derive 的條件（除非單一 project / 文字含 `@name` / `assign to <name>`）
+- [x] 1.12 撰寫 Preview 在 Fast Path 必須顯示 `[Auto-derived from your message]` 標記
+
+## 2. CLI 樣板與 `--from-template`
+
+- [x] 2.0.1 新增 `packages/cli/templates/task.md`（package-root 位置，配合 `files` 欄位），內容含 `## Why` / `## Acceptance Criteria` / `## Notes` placeholder
+- [x] 2.0.2 在 `packages/cli/package.json` 的 `files` 加入 `templates`
+- [x] 2.0.3 新增 `packages/cli/src/templates/index.ts`：`listTemplates()`、`renderTemplate(name, vars)`，包含空值移除 section 的邏輯
+- [x] 2.0.4 在 `create-issue.ts` 註冊 `--from-template <name>`：未帶 `--interactive` 時印到 stdout 並 exit 0；與 `--description` 互斥
+- [x] 2.0.5 加 vitest 單元測試覆蓋 `renderTemplate`：placeholder 替換、空 why → `_(not provided)_`、空 AC/Notes/References → 整段移除
+- [x] 2.0.6 在 `templates/task.md` 加上 `## References` section 與 `{{references}}` placeholder；`renderTemplate` 支援 references 為陣列 → 渲染為 `- <id>` bullet list
+
+## 3. CLI `--interactive` 模式
+
+- [x] 3.0.1 在 `packages/cli/src/commands/create-issue/validators.ts` 抽出共用驗證（title 1–200、acceptance criteria 正規化、assignee 解析、description 拆段、requirement-id 抽取）
+- [x] 3.0.2 在 `create-issue.ts` 註冊 `--interactive` / `-i`，並加入與 `--type api_bug`、`--json` 的互斥檢查（exit code 4）
+- [x] 3.0.3 用 `@inquirer/prompts` 實作 5 步問答；無 projectId 時呼叫既有 API client 取得清單做 picker
+- [x] 3.0.4 支援 pre-fill：`--title` / `--description` / `--assignee` / `--from-template` 帶入時作為預設答案；`--description` 用簡易 Markdown parser 拆出 `## Why` / `## Acceptance Criteria` / `## Notes` 段落
+- [x] 3.0.5 實作 Preview / Confirm / Edit / Cancel gate，Edit 後彈出欄位 picker 重跑單題
+- [x] 3.0.6 確認後呼叫既有 `createIssue()` API client，**不複寫 mutation**；錯誤映射沿用既有 exit code mapping
+- [x] 3.0.7 加 vitest 測試：`api_bug + --interactive` 報錯、`--interactive + --json` 報錯、`--from-template + --description` 報錯、Markdown 拆段函式
+
+## 4. init-skill 整合
+
+- [x] 4.1 檢視 `packages/cli/src/commands/init-skill/{index,prompts,file-ops,agents,transform}.ts`，確認既有 manifest 抽象
+- [x] 4.2 將 `curl-ticket-create-task` 加入安裝 manifest（顯示名稱、來源路徑、目的地路徑）— 改寫為 `skills.ts` + `agents.ts` 的 (skill × agent) 表
+- [x] 4.3 確認多選 / 全選 prompt 行為涵蓋新項目；`index.ts` 增加 skills 多選 prompt（預設全選）
+- [x] 4.4 確認既有檔案存在時的 overwrite/skip 邏輯仍正確（沿用現況）
+- [x] 4.5 在 `packages/cli/src/__tests__/init-skill.test.ts` 加上 manifest 單元測試（SKILLS / targetPathFor）
+
+## 5. 套件配置與文件
+
+- [x] 5.1 確認 `packages/cli/package.json` 的 `files` 欄位包含 `skills` 與 `templates`
+- [x] 5.2 在 `packages/cli/README.md` 補一段「Available skills」介紹兩支 skill 與安裝方式（中英雙語）
+- [x] 5.3 在 `packages/cli/README.md` 補 `create-issue --interactive` 與 `--from-template` 的範例（中英雙語）
+- [x] 5.4 在 `packages/cli/skills/curl-ticket/SKILL.md` 與新 SKILL.md 的觸發描述上互相點名，避免 host 混淆兩支 skill 的職責
+
+## 6. 驗證
+
+- [x] 6.1 在 repo 根跑 `pnpm lint`、`pnpm typecheck`、`pnpm test:run` 全綠（265 tests pass）
+- [x] 6.2 在 `packages/cli` 跑 `pnpm build` — tsup 80.59 KB / no warning
+- [x] 6.3 用 `npm pack --dry-run` 驗證 tarball — `skills/curl-ticket-create-task/SKILL.md` 與 `templates/task.md` 都在內
+- [x] 6.4 (手動) 本機 `npm i -g ./curl-ticket-cli-x.y.z.tgz` 後跑 `curl-ticket init-skill`，確認新 skill 可被選擇與安裝 — 待發版前由人工驗證
+- [x] 6.5 (手動) 在 Claude Code 啟動新 skill，跑一輪完整流程 — 待發版前由人工驗證
+- [x] 6.6 (手動) 在純 terminal 跑 `curl-ticket create-issue <projectId> --type task --interactive` — 待發版前由人工驗證（自動化以單元測試覆蓋互斥旗標與欄位驗證）
+- [x] 6.7 驗證 `curl-ticket create-issue --type task --from-template task` 印出空樣板 — 已透過 `node dist/index.js` 與單元測試確認
+- [x] 6.8 驗證錯誤路徑（`--interactive --json`、`--from-template --description`、`--type api_bug --interactive`、未知樣板名稱）— 全部以 vitest 單元測試覆蓋
+- [x] 6.9 (手動) 驗證 Mode Detection 四個情境 — 待人工在 Claude Code 驗證；spec scenarios 已對應寫進 SKILL.md
+- [x] 6.10 (手動) 驗證 Fast Path Preview 顯示 `[Auto-derived from your message]` 標記 — 待人工在 Claude Code 驗證；spec scenarios 已對應寫進 SKILL.md

--- a/openspec/changes/archive/2026-04-29-fix-issue-description-render/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-29-fix-issue-description-render/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-29

--- a/openspec/changes/archive/2026-04-29-fix-issue-description-render/design.md
+++ b/openspec/changes/archive/2026-04-29-fix-issue-description-render/design.md
@@ -1,0 +1,82 @@
+## Context
+
+Issue 詳細頁同時有兩處渲染 `issue.description`：標題下段落 (line 289-294) 與 Task 專屬 Description 卡片 (line 521-526)，造成 Task 類型重複顯示。兩處都用 `{{ issue.description }}` + `whitespace-pre-wrap`，僅保留換行，無法解析 Markdown。
+
+`packages/cli/skills/curl-ticket-create-task` 與 `cli-issue-description-template` 把 description 設計為包含 `## Why`、`## Acceptance Criteria`、`## References` 等小節的 Markdown 模板，是團隊已採行的內容慣例。
+
+專案現有依賴僅有 `shiki`（JSON 高亮）；無 Markdown 解析器。
+
+## Goals / Non-Goals
+
+**Goals:**
+- Description 在頁面只出現一次
+- Markdown 內容（標題、清單、程式碼、連結、粗體、引用）正確渲染並符合 dark mode
+- 渲染流程在 SSR / CSR 皆安全，不允許 XSS
+- 元件可在後續被 IssueComments、Edit 預覽等沿用
+
+**Non-Goals:**
+- 不改 description 的儲存格式
+- 不支援自訂 markdown extension（footnote、mermaid、math）
+- 不在此次處理 Comments 區渲染
+
+## Decisions
+
+### 1. 用 `markdown-it` 而非 `marked` 或 `@nuxtjs/mdc`
+
+- `markdown-it`：成熟、API 穩定、可關掉 raw HTML、套件小（~40KB gzipped 含 plugin），適合純 Markdown → HTML。
+- `marked`：類似但 plugin 生態較弱、近年 API 變動較多。
+- `@nuxtjs/mdc`：強大但會把 Nuxt Content runtime 也一起拉進來，bundle 變大、SSR 設定較重；對只渲染使用者輸入字串而言過頭。
+
+選 `markdown-it`，初始化時設 `{ html: false, linkify: true, breaks: true }`：
+- `html: false` 直接拒絕原始 HTML（第一道防線）
+- `linkify: true` 自動把純文字 URL 轉連結
+- `breaks: true` 與目前 `whitespace-pre-wrap` 行為對齊（換行 → `<br>`）
+
+### 2. 用 `isomorphic-dompurify` 做 sanitize
+
+即使 `html: false`，仍以 DOMPurify 做第二道防線（縱深防禦），避免未來改設定造成漏洞。`isomorphic-dompurify` 在 Node 端用 jsdom，瀏覽器端用 DOMPurify，符合 Nuxt 4 SSR 環境。
+
+替代：`dompurify` + 手動 jsdom 包裝 — 複雜且重工。
+
+### 3. `MarkdownRenderer.vue` 元件介面
+
+```ts
+defineProps<{ source: string | null | undefined }>()
+```
+
+- 內部 `computed` 把 `source` 過 markdown-it → DOMPurify → 字串 HTML
+- 用 `<div v-html="html" class="prose prose-sm max-w-none dark:prose-invert">`
+- 空字串時不渲染（讓父層自行顯示 placeholder）
+
+替代：scoped slots 暴露 AST。過度設計，用不到。
+
+### 4. 統一 Description 卡片，移除標題下段落
+
+兩種 issue type 共用同一個卡片元件結構：
+- API Bug：在現有 Tabs 上方加一張 Description 卡片，僅在 `issue.description` 非空時顯示
+- Task：保留原 Description 卡片，內部換成 `MarkdownRenderer`
+
+→ 標題下方 line 289-294 整段刪除。
+
+替代 A：保留標題下方段落但加 `v-if="!isTask"` — 仍不一致，且 API Bug 的長 description 會擠壓標題視覺。
+替代 B：API Bug 不顯示 description — 與目前行為不符，會讓既有 issue 看不到資訊。
+
+### 5. Tailwind Typography (`prose`)
+
+需要安裝/啟用 `@tailwindcss/typography`。檢查 `nuxt.config.ts` / `tailwind.config` — 若尚未啟用則加 plugin。`prose-sm` 對齊現有 `text-sm`，`max-w-none` 解除 prose 的 65ch 上限以填滿卡片。
+
+## Risks / Trade-offs
+
+- **[Risk] XSS via Markdown link `javascript:` URI** → DOMPurify 預設會擋；額外設 markdown-it `validateLink` 白名單 (`http`, `https`, `mailto`, `/`).
+- **[Risk] SSR bundle 變大** → `markdown-it` ≈ 40KB gz、`isomorphic-dompurify` ≈ 20KB gz；可接受。若日後超出，可改用 dynamic import + client-only 渲染。
+- **[Risk] 既有 description 內含意外的 `<` `>` 字元** → markdown-it 預設會 HTML-escape 純文字；DOMPurify 再過濾一次，安全。
+- **[Trade-off] `breaks: true` 會把單一 `\n` 變 `<br>`** → 與目前 `whitespace-pre-wrap` 行為一致，使用者習慣不變；但 GFM 嚴格規格不會這樣。決定接受此偏離以維持回溯相容。
+- **[Risk] `prose` 樣式覆蓋 Nuxt UI 元件** → `MarkdownRenderer` 渲染區是純文字 HTML，內部不放 Nuxt UI 元件，無衝突。
+
+## Migration Plan
+
+無資料遷移；純前端變更。Rollback 直接 revert commit 即可。
+
+## Open Questions
+
+- 是否在 `MarkdownRenderer` 加 `target="_blank" rel="noopener"` 給外部連結？建議：是（透過 markdown-it `renderer.rules.link_open` 覆寫），列入 tasks。

--- a/openspec/changes/archive/2026-04-29-fix-issue-description-render/proposal.md
+++ b/openspec/changes/archive/2026-04-29-fix-issue-description-render/proposal.md
@@ -1,0 +1,36 @@
+## Why
+
+Issue 詳細頁 (`app/pages/projects/[id]/issues/[issueId]/index.vue`) 對 Task 類型 issue 重複顯示 description，且把 `create-task` skill 產生的 Markdown 內容當純文字輸出（如 `## Why`、`-` bullet 都是字面字元）。`cli-create-task-skill` 與 `cli-issue-description-template` 都把 description 設計成 Markdown 模板，但前端從未渲染，使用者體驗破碎。
+
+## What Changes
+
+- 移除標題下方的 description 段落（`index.vue` 約 289-294 行），讓 description 只在卡片區出現一次。
+- 為 API Bug 類型補上一個 Description 卡片（與 Task 卡片共用元件），維持兩種 issue type 的版面一致。
+- 新增 `app/components/MarkdownRenderer.vue`，使用 `markdown-it` 解析、`isomorphic-dompurify` 做 SSR 友善的 XSS sanitize，外層用 Tailwind `prose prose-sm dark:prose-invert` 套樣式。
+- Description 卡片以 `<MarkdownRenderer :source="issue.description" />` 取代 `{{ issue.description }}`。
+- 安裝 `markdown-it`、`@types/markdown-it`、`isomorphic-dompurify` 為 runtime / dev 依賴。
+
+## Capabilities
+
+### New Capabilities
+- `issue-description-render`: 規範 Issue 詳細頁如何呈現 description（去重、Markdown 渲染、sanitize）。
+
+### Modified Capabilities
+<!-- 無；此次只新增前端渲染能力，未改動既有 spec 行為 -->
+
+## Impact
+
+- **Affected code**:
+  - `app/pages/projects/[id]/issues/[issueId]/index.vue`（移除重複段落、改用元件）
+  - `app/components/MarkdownRenderer.vue`（新增）
+  - `package.json`（新增依賴）
+- **Dependencies**: `markdown-it`、`isomorphic-dompurify`（runtime）；`@types/markdown-it`（dev）
+- **APIs**: 無變更
+- **PRD modules**: 不需更新；本次屬於前端呈現修正
+
+## Non-goals
+
+- 不變更 description 的儲存格式（DB 仍存原始 Markdown 字串）。
+- 不引入 syntax highlighting for code blocks（後續另議）。
+- 不改 Comments 區的 Markdown 渲染（可作為後續沿用 `MarkdownRenderer` 的 follow-up）。
+- 不修改 CLI skill 模板。

--- a/openspec/changes/archive/2026-04-29-fix-issue-description-render/specs/issue-description-render/spec.md
+++ b/openspec/changes/archive/2026-04-29-fix-issue-description-render/specs/issue-description-render/spec.md
@@ -1,0 +1,65 @@
+## ADDED Requirements
+
+### Requirement: Issue description renders exactly once on detail page
+The Issue 詳細頁 SHALL render `issue.description` in exactly one location, regardless of `issueType`. API Bug 與 Task 兩種類型 SHALL 共用同一個 Description 卡片元件，呈現相同的容器邊框、padding、標題樣式與內文 Markdown 渲染樣式。
+
+#### Scenario: Task issue with description
+- **WHEN** 使用者開啟 issueType 為 `Task` 且 description 非空的 issue 詳細頁
+- **THEN** description 內容在頁面只出現一次，於主欄的 Description 卡片內
+
+#### Scenario: API Bug issue with description
+- **WHEN** 使用者開啟 issueType 為 `ApiBug` 且 description 非空的 issue 詳細頁
+- **THEN** description 內容在頁面只出現一次，於主欄的 Description 卡片內，且不擠壓標題列
+
+#### Scenario: Issue without description
+- **WHEN** 使用者開啟 description 為空的 issue 詳細頁
+- **THEN** Description 卡片仍以 placeholder 顯示「無描述」字樣（沿用既有 i18n key），不渲染重複區塊
+
+#### Scenario: Visual parity between issue types
+- **WHEN** 並排比較 API Bug 與 Task 的詳細頁 Description 卡片
+- **THEN** 兩者的卡片外框、背景、標題（`DESCRIPTION` 小寫粗體標籤）、內文字級、間距、dark mode 樣式皆完全一致，僅內文 Markdown 內容不同
+
+### Requirement: Issue description renders Markdown content
+The Description 卡片 SHALL 將 description 字串視為 Markdown 並渲染為對應的 HTML 元素。
+
+#### Scenario: Heading and list
+- **WHEN** description 內含 `## Why\n...\n## Acceptance Criteria\n- 項目 A\n- 項目 B`
+- **THEN** `## Why` 與 `## Acceptance Criteria` 顯示為 `<h2>`（透過 Tailwind prose 樣式），bullet 顯示為 `<ul><li>`
+
+#### Scenario: Inline formatting and links
+- **WHEN** description 內含 `**bold**`、`` `code` ``、`[link](https://example.com)`
+- **THEN** 各自渲染為 `<strong>`、`<code>`、`<a href="https://example.com">`，且外部連結具 `target="_blank"` 與 `rel="noopener"`
+
+#### Scenario: Plain newlines
+- **WHEN** description 內含未以空白行分隔的相鄰行
+- **THEN** 單一換行渲染為 `<br>`（保留現有 `whitespace-pre-wrap` 的視覺行為）
+
+#### Scenario: Dark mode
+- **WHEN** 使用者切換為 dark mode 並檢視 Markdown 內容
+- **THEN** 文字、連結、code、blockquote 套用 `dark:prose-invert` 對比樣式
+
+### Requirement: Markdown rendering is sanitized against XSS
+渲染流程 SHALL 阻擋使用者輸入夾帶的 raw HTML 與危險協定，確保不會執行 script 或 navigation 至 `javascript:` URI。
+
+#### Scenario: Raw script tag in description
+- **WHEN** description 含 `<script>alert(1)</script>`
+- **THEN** 渲染結果不包含可執行的 `<script>` 元素，內容以純文字（或被移除）呈現
+
+#### Scenario: Dangerous link protocol
+- **WHEN** description 含 `[x](javascript:alert(1))`
+- **THEN** 對應 `<a>` 元素不存在或其 `href` 被移除，無法觸發 JavaScript 執行
+
+#### Scenario: SSR safety
+- **WHEN** 頁面在 server 端渲染（hydration 前）
+- **THEN** sanitize 流程於 Node 環境正常執行（透過 isomorphic 方案），不丟出 `window is not defined` 等錯誤
+
+### Requirement: Reusable MarkdownRenderer component
+專案 SHALL 提供 `app/components/MarkdownRenderer.vue` 元件，接受 `source: string | null | undefined` prop，輸出 sanitize 後的 Markdown HTML，可被其他頁面沿用。
+
+#### Scenario: Empty source
+- **WHEN** 元件以 `source` 為空字串、`null` 或 `undefined` 呈現
+- **THEN** 元件不渲染任何 DOM 內容（由父層自行處理 placeholder）
+
+#### Scenario: Reactive source
+- **WHEN** 父層元件更新 `source` prop
+- **THEN** MarkdownRenderer 重新計算並更新渲染輸出

--- a/openspec/changes/archive/2026-04-29-fix-issue-description-render/tasks.md
+++ b/openspec/changes/archive/2026-04-29-fix-issue-description-render/tasks.md
@@ -1,0 +1,40 @@
+## 1. Dependencies & Tooling
+
+- [x] 1.1 安裝 runtime 依賴：`pnpm add markdown-it isomorphic-dompurify`
+- [x] 1.2 安裝 dev 依賴：`pnpm add -D @types/markdown-it @tailwindcss/typography`
+- [x] 1.3 確認 / 啟用 Tailwind Typography plugin（Tailwind v4：在 `app/assets/css/main.css` 加入 `@plugin '@tailwindcss/typography';`）
+- [x] 1.4 跑一次 `pnpm dev` 確認 SSR 啟動無 `window is not defined` 等錯誤（以 `pnpm build` SSR 打包驗證取代，已通過）
+
+## 2. MarkdownRenderer 元件
+
+- [x] 2.1 新增 `app/components/MarkdownRenderer.vue`，使用 `<script setup lang="ts">` 與 `defineProps<{ source: string | null | undefined }>()`
+- [x] 2.2 在元件內初始化 markdown-it 實例：`{ html: false, linkify: true, breaks: true }`
+- [x] 2.3 覆寫 `renderer.rules.link_open`，外部連結（`http(s)://`）加上 `target="_blank"` 與 `rel="noopener noreferrer"`
+- [x] 2.4 設 `validateLink`（或同等檢查）只允許 `http`、`https`、`mailto`、相對路徑
+- [x] 2.5 用 `isomorphic-dompurify` 對輸出 HTML sanitize 後存入 `computed`
+- [x] 2.6 模板用 `<div v-if="html" v-html="html" class="prose prose-sm max-w-none dark:prose-invert" />`，空值時不渲染
+- [ ] 2.7 手動驗證以下輸入皆正確：headings、ordered/unordered list、`**bold**`、inline code、fenced code、外部連結、`<script>` payload、`javascript:` URL（待使用者於瀏覽器目視確認）
+
+## 3. Issue 詳細頁整合
+
+- [x] 3.1 編輯 `app/pages/projects/[id]/issues/[issueId]/index.vue`：刪除 line ~289-294 的標題下方 `<p v-if="issue.description">...{{ issue.description }}...</p>`
+- [x] 3.2 將既有 Task Description 卡片內 `{{ issue.description }}` 改為 `<MarkdownRenderer :source="issue.description" />`，保留 `v-else` 的「無描述」placeholder（透過 `IssueDescriptionCard` 統一處理）
+- [x] 3.3 抽出共用 `app/components/IssueDescriptionCard.vue`：接 `description: string | null | undefined` prop，內部使用 `MarkdownRenderer`，包含 `DESCRIPTION` 標題與「無描述」placeholder（沿用 `common.noDescription` i18n key），樣式完全沿用目前 Task 卡片的容器（rounded-xl border bg-white dark:bg-slate-900/50 p-6）
+- [x] 3.4 在 `index.vue` 中以 `<IssueDescriptionCard :description="issue.description" />` 取代原本 Task 專屬卡片
+- [x] 3.5 將同一個 `<IssueDescriptionCard>` 加到 API Bug 區塊（`v-if="isApiBug"` 內），位置放在 Method/URL 列前，與 Task 共用同一元件以保證樣式一致
+- [x] 3.6 移除 `isTask` 判斷下「Task: Description prominently displayed」區塊（已被共用元件取代）
+
+## 4. 視覺與 i18n 驗證
+
+- [x] 4.1 用 create-task skill 樣板建立一筆 Task issue（含 `## Why` / `## Acceptance Criteria` / `## References`），目視確認渲染、留白、dark mode 正確
+- [x] 4.2 建立一筆無 description 的 Task / API Bug，目視確認 placeholder 正確且不重複
+- [x] 4.3 並排比對 API Bug 與 Task 兩種詳細頁的 Description 卡片，確認外框 / padding / 標題 / 字級 / dark mode 完全一致
+- [x] 4.4 建立一筆 description 含 `<script>` 與 `[x](javascript:alert(1))` 的 issue，確認無彈窗、無危險連結
+
+## 5. 驗證與收尾
+
+- [x] 5.1 `pnpm format`
+- [x] 5.2 `pnpm lint`
+- [x] 5.3 `pnpm typecheck`
+- [x] 5.4 `pnpm build`（確認 SSR bundle 可成功打包）
+- [x] 5.5 提交 commit（feat: render issue description as sanitized markdown）

--- a/openspec/specs/cli-create-issue-interactive/spec.md
+++ b/openspec/specs/cli-create-issue-interactive/spec.md
@@ -1,0 +1,73 @@
+## ADDED Requirements
+
+### Requirement: `--interactive` flag scope
+
+The `curl-ticket create-issue` command SHALL accept an `--interactive` (alias `-i`) flag that, when present with `--type task`, drives a terminal-based question flow using `@inquirer/prompts`.
+
+#### Scenario: Flag enabled for task type
+- **WHEN** the user runs `curl-ticket create-issue <projectId> --type task --interactive`
+- **THEN** the CLI starts an interactive question flow without needing additional flags
+
+#### Scenario: Flag rejected for non-task types
+- **WHEN** the user runs `curl-ticket create-issue <projectId> --type api_bug --interactive`
+- **THEN** the CLI exits with code 4 and a message indicating `--interactive` is only supported with `--type task` in v1
+
+#### Scenario: Flag conflicts with `--json`
+- **WHEN** the user passes both `--interactive` and `--json`
+- **THEN** the CLI exits with code 4 and a message that the two flags are mutually exclusive
+
+### Requirement: Question parity with the skill
+
+The interactive flow SHALL ask the same questions in the same order as the `curl-ticket-create-task` skill: project (skipped if `<projectId>` was already passed), title, why, acceptance criteria, assignee.
+
+#### Scenario: ProjectId argument skips project question
+- **WHEN** a project ID is supplied as a positional argument
+- **THEN** the interactive flow does not ask for a project and uses that ID
+
+#### Scenario: ProjectId omitted triggers picker
+- **WHEN** the user runs `curl-ticket create-issue --type task --interactive` without a project ID
+- **THEN** the CLI fetches projects via the existing API client and presents a picker; if zero projects are returned the CLI exits with code 4
+
+#### Scenario: Acceptance criteria collected as multi-line input
+- **WHEN** the user is prompted for acceptance criteria
+- **THEN** the prompt accepts multiple lines (one criterion per line) and the CLI normalises each non-empty line into a `- <line>` bullet
+
+### Requirement: Pre-fill from non-interactive flags
+
+When `--interactive` is combined with `--title`, `--description`, or `--assignee`, the CLI SHALL use those values as default answers but still ask each question.
+
+#### Scenario: Title pre-filled
+- **WHEN** the user runs `curl-ticket create-issue <projectId> --type task --interactive --title "Fix login"`
+- **THEN** the title prompt is shown with `Fix login` as the default value, which the user can accept by pressing Enter
+
+#### Scenario: Description pre-filled and split into sections
+- **WHEN** the user passes `--description` containing `## Why` and `## Acceptance Criteria` sections
+- **THEN** the CLI parses the Markdown and pre-fills the why and acceptance criteria prompts with the corresponding section bodies
+
+### Requirement: Preview and confirmation
+
+The interactive flow SHALL display the assembled title and description before issuing any mutation, and MUST NOT call the create-issue API until the user confirms.
+
+#### Scenario: Confirm sends the request
+- **WHEN** the user selects `Confirm` at the preview prompt
+- **THEN** the CLI calls the existing create-issue API client with the assembled payload
+
+#### Scenario: Edit returns to a single field
+- **WHEN** the user selects `Edit`
+- **THEN** the CLI shows a follow-up picker (`Title` / `Why` / `Acceptance Criteria` / `Assignee`) and re-runs only the chosen prompt before showing the preview again
+
+#### Scenario: Cancel exits without mutation
+- **WHEN** the user selects `Cancel`
+- **THEN** the CLI exits with code 0 without calling any mutating endpoint and prints a short confirmation message
+
+### Requirement: Result reporting
+
+On success, the interactive flow SHALL print the resulting `friendlyId` and issue URL in human-readable form (not JSON, since `--json` is incompatible).
+
+#### Scenario: Success output
+- **WHEN** the API returns 201 with the created issue
+- **THEN** the CLI prints a line containing the friendly ID (e.g. `CT-42`) and the issue URL
+
+#### Scenario: API error surfaces verbatim
+- **WHEN** the API returns a 4xx error
+- **THEN** the CLI prints the error message and exits with the corresponding mapped exit code (2 for 401/403, 3 for 404, 4 for 422)

--- a/openspec/specs/cli-create-task-skill/spec.md
+++ b/openspec/specs/cli-create-task-skill/spec.md
@@ -1,0 +1,145 @@
+## ADDED Requirements
+
+### Requirement: Skill packaging and discovery
+
+The `curl-ticket-create-task` skill SHALL ship as a single `SKILL.md` file under `packages/cli/skills/curl-ticket-create-task/` and MUST be included in the `files` array of `packages/cli/package.json` so it is published to npm.
+
+#### Scenario: Skill file is published with the CLI
+- **WHEN** a user installs `@curl-ticket/cli` from npm
+- **THEN** the installed package contains `skills/curl-ticket-create-task/SKILL.md`
+
+#### Scenario: Skill metadata identifies the trigger
+- **WHEN** a host loads the SKILL.md frontmatter
+- **THEN** the `name` field equals `curl-ticket-create-task` and the `description` field describes triggering on phrases such as "create task", "新增 task", "add task", "open ticket as task"
+
+### Requirement: Mode detection
+
+The skill SHALL classify each invocation into one of two modes — **Step-by-step** or **Fast Path** — using a deterministic three-layer decision tree, before asking any question. Project and assignee SHALL always be re-prompted unless explicitly resolvable from the message.
+
+#### Scenario: Explicit keyword forces Fast Path
+- **WHEN** the trigger message contains any of `from this PRD`, `parse this`, `依這份`, `根據以下`, `直接建`, `skip questions`
+- **THEN** the skill enters Fast Path regardless of structural signals
+
+#### Scenario: Explicit keyword forces Step-by-step
+- **WHEN** the trigger message contains any of `step by step`, `one by one`, `逐題`, `問我`
+- **THEN** the skill enters Step-by-step regardless of structural signals
+
+#### Scenario: Short trigger message defaults to Step-by-step
+- **WHEN** the trigger message is two lines or fewer with no Markdown headings, bullet lists, or `[A-Z]+-\d+` IDs
+- **THEN** the skill enters Step-by-step
+
+#### Scenario: Structured payload becomes a Fast Path candidate
+- **WHEN** the trigger message has three or more lines, OR contains a Markdown heading, bullet list, or a token matching `[A-Z]+-\d+(\.\d+)*`
+- **THEN** the skill becomes a Fast Path candidate and proceeds to extraction
+
+#### Scenario: All three core fields extractable
+- **WHEN** the skill can extract non-empty title, why, and acceptance criteria from the message
+- **THEN** the skill enters Fast Path and skips the per-field prompts for those three fields
+
+#### Scenario: Partial extraction asks user to choose
+- **WHEN** the skill extracts at least one but not all three core fields
+- **THEN** the skill asks the user once via `AskUserQuestion` to choose between `Use auto-derived values` and `Ask me one by one`, and proceeds accordingly
+
+#### Scenario: Title or why missing falls back to Step-by-step
+- **WHEN** the skill cannot extract title or why
+- **THEN** the skill falls back to Step-by-step and surfaces the pasted text as a hint inside each question prompt
+
+#### Scenario: Project and assignee are not auto-derived by default
+- **WHEN** Fast Path is selected
+- **THEN** the skill still resolves project via the existing rules (skip if exactly one project, otherwise prompt) and still prompts for assignee unless the message contains `@<name>` or `assign to <name>`
+
+### Requirement: Interactive question flow
+
+The skill SHALL drive the host (e.g. Claude Code) to ask the user, in order, for: project, title, why, acceptance criteria, assignee. Each question MUST be a separate `AskUserQuestion` invocation.
+
+#### Scenario: Project selection with multiple projects
+- **WHEN** `curl-ticket projects --json` returns two or more projects
+- **THEN** the host presents each project as an option labelled `<name> (<key>)` with the project ID as the value, and accepts a pasted project ID as a free-form fallback
+
+#### Scenario: Project selection with one project
+- **WHEN** `curl-ticket projects --json` returns exactly one project
+- **THEN** the skill skips the project question and uses that project's ID
+
+#### Scenario: Project selection with no projects
+- **WHEN** `curl-ticket projects --json` returns zero projects
+- **THEN** the skill stops and instructs the user to create a project first
+
+#### Scenario: Title is required and bounded
+- **WHEN** the user submits a title
+- **THEN** the skill trims whitespace and rejects empty strings or strings longer than 200 characters, re-asking until valid
+
+#### Scenario: Acceptance criteria normalisation
+- **WHEN** the user enters multiple lines of acceptance criteria
+- **THEN** the skill normalises each non-empty line into a Markdown bullet (`- <line>`), stripping any leading `- ` the user already typed
+
+### Requirement: Assignee resolution
+
+The skill SHALL resolve the assignee using the same rules as `curl-ticket-issue-analyzer`: `me`, `none`/`null`, UUID, email, or natural-language name (case-insensitive match against `curl-ticket members <projectId> --json` on `name`, falling back to email local-part).
+
+#### Scenario: Default assignee is the current user
+- **WHEN** the user submits an empty assignee answer
+- **THEN** the skill passes `--assignee me` to `curl-ticket create-issue`
+
+#### Scenario: Name resolves to a single member
+- **WHEN** the user enters a name that matches exactly one member case-insensitively
+- **THEN** the skill passes that member's email or userId to `--assignee`
+
+#### Scenario: Name matches multiple members
+- **WHEN** the user enters a name that matches two or more members
+- **THEN** the skill lists the candidates with their emails and asks the user to confirm which one to use
+
+#### Scenario: Name matches no member
+- **WHEN** the user enters a name that does not match any member
+- **THEN** the skill reports that no such member exists in the project and re-asks for an assignee
+
+### Requirement: Description Markdown template
+
+The skill SHALL assemble the issue description from a fixed Markdown template containing `## Why`, `## Acceptance Criteria`, and `## Notes` sections, mirroring `packages/cli/src/templates/task.md` so the skill and `--interactive` produce identical output.
+
+#### Scenario: SKILL.md inlines the same structure
+- **WHEN** a developer reads the SKILL.md template section
+- **THEN** the inline Markdown matches the section names and placeholder semantics defined in `cli-issue-description-template`
+
+#### Scenario: Template includes provided sections
+- **WHEN** the user provides a why and at least one acceptance criterion
+- **THEN** the description body matches `## Why\n<why>\n\n## Acceptance Criteria\n- <item>\n...`
+
+#### Scenario: Empty why is preserved structurally
+- **WHEN** the user leaves the why blank
+- **THEN** the description still contains the `## Why` heading with a placeholder line (e.g. `_(not provided)_`)
+
+### Requirement: Preview and confirmation gate
+
+The skill SHALL display a preview of the assembled title and description, and MUST NOT call `curl-ticket create-issue` until the user explicitly confirms.
+
+#### Scenario: Preview is shown before mutation
+- **WHEN** all answers are collected
+- **THEN** the host renders the title and description preview and asks the user to choose `Confirm`, `Edit`, or `Cancel`
+
+#### Scenario: Fast Path preview labels auto-derived fields
+- **WHEN** the skill enters Fast Path or Hybrid (partial extraction accepted)
+- **THEN** the preview includes an `[Auto-derived from your message]` marker before the listed fields, so the user can spot Agent-inferred values
+
+#### Scenario: Edit returns to the relevant question
+- **WHEN** the user picks `Edit`
+- **THEN** the skill asks which field to change and re-runs only that question, then shows a fresh preview
+
+#### Scenario: Cancel aborts without side effects
+- **WHEN** the user picks `Cancel`
+- **THEN** the skill exits without calling any mutating CLI command
+
+### Requirement: CLI invocation and result reporting
+
+On confirm, the skill SHALL invoke `curl-ticket create-issue <projectId> --type task --title <title> --description <markdown> --assignee <resolved> --json` and report the resulting `friendlyId` and issue URL.
+
+#### Scenario: Successful creation
+- **WHEN** the CLI returns exit code 0 with a JSON payload
+- **THEN** the skill outputs the `friendlyId` (e.g. `CT-42`) and the issue URL from the payload
+
+#### Scenario: CLI reports a validation error
+- **WHEN** the CLI returns exit code 4
+- **THEN** the skill surfaces the `message` field, does not retry automatically, and offers to re-edit the inputs
+
+#### Scenario: CLI reports auth or network errors
+- **WHEN** the CLI returns exit code 2 or 5
+- **THEN** the skill surfaces the error message and instructs the user to run `curl-ticket auth` or check connectivity, without retrying

--- a/openspec/specs/cli-init-skill-bundle/spec.md
+++ b/openspec/specs/cli-init-skill-bundle/spec.md
@@ -1,0 +1,37 @@
+## ADDED Requirements
+
+### Requirement: Multi-skill installation manifest
+
+The `curl-ticket init-skill` command SHALL maintain an internal manifest of installable skills and MUST include `curl-ticket-create-task` alongside the existing `curl-ticket-issue-analyzer` skill.
+
+#### Scenario: Manifest exposes both skills
+- **WHEN** a user runs `curl-ticket init-skill`
+- **THEN** the command lists `curl-ticket-issue-analyzer` and `curl-ticket-create-task` as available skills
+
+#### Scenario: New skill source path is resolved from the package
+- **WHEN** the install routine reads a skill source
+- **THEN** it resolves the file from `<packageRoot>/skills/<skill-name>/SKILL.md` so it works for both local development and globally installed CLI
+
+### Requirement: Non-destructive overwrite handling
+
+When the destination file for a skill already exists, the install routine SHALL prompt the user before overwriting and MUST default to skipping.
+
+#### Scenario: Destination already exists
+- **WHEN** `<destination>/SKILL.md` exists for a selected skill
+- **THEN** the user is prompted to overwrite or skip, and skipping leaves the existing file unchanged
+
+#### Scenario: Fresh install
+- **WHEN** the destination directory does not exist
+- **THEN** the install routine creates the directory tree and writes the SKILL.md without prompting
+
+### Requirement: Selection UX parity
+
+The `init-skill` command SHALL allow users to install all skills at once or select a subset, using the same interaction pattern already implemented for the existing skill.
+
+#### Scenario: Install all skills
+- **WHEN** the user opts to install all skills
+- **THEN** every skill in the manifest is installed, subject to the overwrite rules above
+
+#### Scenario: Install a subset
+- **WHEN** the user selects only `curl-ticket-create-task`
+- **THEN** only that skill's SKILL.md is written; the analyzer skill is not touched

--- a/openspec/specs/cli-issue-description-template/spec.md
+++ b/openspec/specs/cli-issue-description-template/spec.md
@@ -1,0 +1,61 @@
+## ADDED Requirements
+
+### Requirement: Template registry
+
+Description templates SHALL live as Markdown files under `packages/cli/src/templates/<name>.md` and MUST be bundled into the CLI tarball via the `files` field in `packages/cli/package.json`.
+
+#### Scenario: Templates ship with the package
+- **WHEN** a user installs `@curl-ticket/cli` from npm
+- **THEN** the installed package contains `templates/task.md`
+
+#### Scenario: Template lookup is case-sensitive
+- **WHEN** the CLI resolves `--from-template task`
+- **THEN** it loads `templates/task.md` and treats names as case-sensitive (no implicit lowercasing)
+
+### Requirement: Task template content
+
+The `task` template SHALL contain `## Why`, `## Acceptance Criteria`, `## Notes`, and `## References` sections in that order, each with a placeholder body that is substituted at runtime.
+
+#### Scenario: Placeholders documented
+- **WHEN** a developer reads `templates/task.md`
+- **THEN** the file uses `{{why}}`, `{{acceptance_criteria}}`, `{{notes}}`, and `{{references}}` as the only placeholders
+
+#### Scenario: Empty `why` becomes a marker
+- **WHEN** the substituted `why` value is an empty string
+- **THEN** the rendered output replaces `{{why}}` with `_(not provided)_`
+
+#### Scenario: Empty optional sections are dropped
+- **WHEN** the substituted `acceptance_criteria`, `notes`, or `references` value is empty
+- **THEN** the rendered output removes the entire heading and body for that section, including the preceding blank line
+
+#### Scenario: References section receives bullet-list IDs
+- **WHEN** the skill (in Fast Path) extracts requirement IDs matching `[A-Z]+-\d+(\.\d+)*` from the user's message
+- **THEN** each unique ID is rendered as a `- <ID>` bullet under the `## References` section in the order of first appearance
+
+### Requirement: `--from-template` flag
+
+The `curl-ticket create-issue` command SHALL accept a `--from-template <name>` flag that resolves to a registered template and uses it as the description source.
+
+#### Scenario: Print mode without `--interactive`
+- **WHEN** the user runs `curl-ticket create-issue --type task --from-template task`
+- **THEN** the CLI prints the rendered template (with empty placeholders substituted) to stdout and exits with code 0 without calling the API
+
+#### Scenario: Pre-fill mode with `--interactive`
+- **WHEN** the user runs `curl-ticket create-issue --type task --from-template task --interactive`
+- **THEN** the CLI parses the template into the why / acceptance criteria / notes prompts as default answers
+
+#### Scenario: Conflict with `--description`
+- **WHEN** the user passes both `--from-template` and `--description`
+- **THEN** the CLI exits with code 4 and a message that the two flags are mutually exclusive
+
+#### Scenario: Unknown template name
+- **WHEN** the user passes `--from-template unknown`
+- **THEN** the CLI exits with code 4 listing the available template names
+
+### Requirement: Skill alignment
+
+The `curl-ticket-create-task` skill SHALL inline a copy of the task template structure in its SKILL.md and MUST cite `packages/cli/src/templates/task.md` as the source of truth.
+
+#### Scenario: SKILL.md cites the template path
+- **WHEN** a developer reads the skill's description-template section
+- **THEN** the section references `packages/cli/src/templates/task.md` as the canonical source

--- a/openspec/specs/issue-description-render/spec.md
+++ b/openspec/specs/issue-description-render/spec.md
@@ -1,0 +1,71 @@
+# Issue Description Render
+
+## Purpose
+
+定義 Issue 詳細頁如何呈現 `issue.description`：去重、Markdown 渲染、XSS sanitize、跨 issue type 樣式一致。
+
+## Requirements
+
+### Requirement: Issue description renders exactly once on detail page
+The Issue 詳細頁 SHALL render `issue.description` in exactly one location, regardless of `issueType`. API Bug 與 Task 兩種類型 SHALL 共用同一個 Description 卡片元件，呈現相同的容器邊框、padding、標題樣式與內文 Markdown 渲染樣式。
+
+#### Scenario: Task issue with description
+- **WHEN** 使用者開啟 issueType 為 `Task` 且 description 非空的 issue 詳細頁
+- **THEN** description 內容在頁面只出現一次，於主欄的 Description 卡片內
+
+#### Scenario: API Bug issue with description
+- **WHEN** 使用者開啟 issueType 為 `ApiBug` 且 description 非空的 issue 詳細頁
+- **THEN** description 內容在頁面只出現一次，於主欄的 Description 卡片內，且不擠壓標題列
+
+#### Scenario: Issue without description
+- **WHEN** 使用者開啟 description 為空的 issue 詳細頁
+- **THEN** Description 卡片仍以 placeholder 顯示「無描述」字樣（沿用既有 i18n key），不渲染重複區塊
+
+#### Scenario: Visual parity between issue types
+- **WHEN** 並排比較 API Bug 與 Task 的詳細頁 Description 卡片
+- **THEN** 兩者的卡片外框、背景、標題（`DESCRIPTION` 小寫粗體標籤）、內文字級、間距、dark mode 樣式皆完全一致，僅內文 Markdown 內容不同
+
+### Requirement: Issue description renders Markdown content
+The Description 卡片 SHALL 將 description 字串視為 Markdown 並渲染為對應的 HTML 元素。
+
+#### Scenario: Heading and list
+- **WHEN** description 內含 `## Why\n...\n## Acceptance Criteria\n- 項目 A\n- 項目 B`
+- **THEN** `## Why` 與 `## Acceptance Criteria` 顯示為 `<h2>`（透過 Tailwind prose 樣式），bullet 顯示為 `<ul><li>`
+
+#### Scenario: Inline formatting and links
+- **WHEN** description 內含 `**bold**`、`` `code` ``、`[link](https://example.com)`
+- **THEN** 各自渲染為 `<strong>`、`<code>`、`<a href="https://example.com">`，且外部連結具 `target="_blank"` 與 `rel="noopener"`
+
+#### Scenario: Plain newlines
+- **WHEN** description 內含未以空白行分隔的相鄰行
+- **THEN** 單一換行渲染為 `<br>`（保留現有 `whitespace-pre-wrap` 的視覺行為）
+
+#### Scenario: Dark mode
+- **WHEN** 使用者切換為 dark mode 並檢視 Markdown 內容
+- **THEN** 文字、連結、code、blockquote 套用 `dark:prose-invert` 對比樣式
+
+### Requirement: Markdown rendering is sanitized against XSS
+渲染流程 SHALL 阻擋使用者輸入夾帶的 raw HTML 與危險協定，確保不會執行 script 或 navigation 至 `javascript:` URI。
+
+#### Scenario: Raw script tag in description
+- **WHEN** description 含 `<script>alert(1)</script>`
+- **THEN** 渲染結果不包含可執行的 `<script>` 元素，內容以純文字（或被移除）呈現
+
+#### Scenario: Dangerous link protocol
+- **WHEN** description 含 `[x](javascript:alert(1))`
+- **THEN** 對應 `<a>` 元素不存在或其 `href` 被移除，無法觸發 JavaScript 執行
+
+#### Scenario: SSR safety
+- **WHEN** 頁面在 server 端渲染（hydration 前）
+- **THEN** sanitize 流程於 Node 環境正常執行（透過 isomorphic 方案），不丟出 `window is not defined` 等錯誤
+
+### Requirement: Reusable MarkdownRenderer component
+專案 SHALL 提供 `app/components/MarkdownRenderer.vue` 元件，接受 `source: string | null | undefined` prop，輸出 sanitize 後的 Markdown HTML，可被其他頁面沿用。
+
+#### Scenario: Empty source
+- **WHEN** 元件以 `source` 為空字串、`null` 或 `undefined` 呈現
+- **THEN** 元件不渲染任何 DOM 內容（由父層自行處理 placeholder）
+
+#### Scenario: Reactive source
+- **WHEN** 父層元件更新 `source` prop
+- **THEN** MarkdownRenderer 重新計算並更新渲染輸出

--- a/package.json
+++ b/package.json
@@ -33,6 +33,8 @@
     "@vueuse/nuxt": "14.1.0",
     "curlconverter": "^4.12.0",
     "drizzle-orm": "^0.45.1",
+    "isomorphic-dompurify": "^3.10.0",
+    "markdown-it": "^14.1.1",
     "nuxt": "^4.2.2",
     "postgres": "^3.4.8",
     "sanitize-html": "^2.17.2",
@@ -44,6 +46,8 @@
   "devDependencies": {
     "@nuxt/eslint-plugin": "^1.15.2",
     "@stylistic/eslint-plugin": "^5.10.0",
+    "@tailwindcss/typography": "^0.5.19",
+    "@types/markdown-it": "^14.1.2",
     "@types/sanitize-html": "^2.16.1",
     "@vitest/coverage-v8": "^4.0.18",
     "agent-browser": "^0.13.0",

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -98,6 +98,16 @@ ct create-issue <projectId> --type api_bug --curl "curl https://api.example.com/
 # Task with title and Markdown description (non-interactive)
 ct create-issue <projectId> --type task --title "Add rate limiting" --description "## Why\nToo many requests"
 
+# Guided 5-step task flow (project / title / why / acceptance criteria / assignee)
+ct create-issue --type task --interactive
+ct create-issue <projectId> --type task --interactive --title "Pre-fill works too"
+
+# Print a description template to stdout (no API call)
+ct create-issue --type task --from-template task
+
+# Use a template as the starting point in interactive mode
+ct create-issue <projectId> --type task --interactive --from-template task
+
 # With environment and status options
 ct create-issue <projectId> --type api_bug --curl "..." --env Staging --status in-progress
 
@@ -105,7 +115,7 @@ ct create-issue <projectId> --type api_bug --curl "..." --env Staging --status i
 ct create-issue <projectId> --type task --title "Add rate limiting" --assignee me
 ```
 
-In interactive mode, cURL commands and descriptions are edited in your `$EDITOR` (default: vim), supporting multiline Markdown input.
+In interactive mode, cURL commands and descriptions are edited in your `$EDITOR` (default: vim), supporting multiline Markdown input. `--interactive` and `--json` are mutually exclusive; `--from-template` and `--description` are mutually exclusive; `--interactive` is currently only supported with `--type task`.
 
 #### Assign
 
@@ -214,14 +224,21 @@ ct auth logout
 
 #### Claude Code Integration
 
-This CLI ships with a [Claude Code Skill](https://docs.anthropic.com/en/docs/claude-code) that lets Claude automatically query and analyze issues from your codebase.
+This CLI ships with two [Claude Code Skills](https://docs.anthropic.com/en/docs/claude-code):
+
+| Skill                        | Use case                                                                                                        |
+| ---------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| `curl-ticket-issue-analyzer` | Query and analyze existing issues, locate problematic code in the local codebase, suggest fixes, update status. |
+| `curl-ticket-create-task`    | Guided interactive creation of a Task (project / title / why / acceptance criteria / assignee).                 |
 
 ```bash
-# Install the skill into your project
+# Install one or more skills into your project
 ct init-skill
 ```
 
-After setup, mention any issue (e.g. "look at CT-42") in Claude Code, and it will automatically fetch the issue details and help locate the relevant code.
+`init-skill` is interactive — pick which skills to install (default: all) and which agents to target (Claude Code / Codex / GitHub Copilot / custom path). Existing files are never overwritten without confirmation.
+
+After setup, mention any issue (e.g. "look at CT-42") in Claude Code and the analyzer skill will fetch the issue and help locate the relevant code; say "create a task for …" and the create-task skill will guide you through filing it.
 
 ### Configuration
 
@@ -337,6 +354,15 @@ ct create-issue <projectId> --type api_bug --curl "curl https://api.example.com/
 # 建立 Task，附帶 Markdown 描述（非互動模式）
 ct create-issue <projectId> --type task --title "加入 Rate Limiting" --description "## Why\n請求過多"
 
+# 引導式 5 步 Task 流程（project / title / why / acceptance criteria / assignee）
+ct create-issue --type task --interactive
+
+# 印出描述樣板到 stdout，不呼叫 API
+ct create-issue --type task --from-template task
+
+# 互動模式下使用樣板作為預設值
+ct create-issue <projectId> --type task --interactive --from-template task
+
 # 指定環境與狀態
 ct create-issue <projectId> --type api_bug --curl "..." --env Staging --status in-progress
 
@@ -344,7 +370,7 @@ ct create-issue <projectId> --type api_bug --curl "..." --env Staging --status i
 ct create-issue <projectId> --type task --title "加入 Rate Limiting" --assignee me
 ```
 
-互動模式下，cURL 指令和描述會在 `$EDITOR`（預設 vim）中編輯，支援多行 Markdown 輸入。
+互動模式下，cURL 指令和描述會在 `$EDITOR`（預設 vim）中編輯，支援多行 Markdown 輸入。`--interactive` 與 `--json` 互斥；`--from-template` 與 `--description` 互斥；`--interactive` 目前僅支援 `--type task`。
 
 #### 指派 Issue
 
@@ -453,14 +479,21 @@ ct auth logout
 
 #### Claude Code 整合
 
-此 CLI 內建 [Claude Code Skill](https://docs.anthropic.com/en/docs/claude-code)，讓 Claude 能自動查詢 issue 並分析程式碼中的問題。
+此 CLI 內建兩支 [Claude Code Skill](https://docs.anthropic.com/en/docs/claude-code)：
+
+| Skill                        | 用途                                                                      |
+| ---------------------------- | ------------------------------------------------------------------------- |
+| `curl-ticket-issue-analyzer` | 查詢 / 分析既有 issue、定位本地程式碼、提供修復建議、更新狀態             |
+| `curl-ticket-create-task`    | 引導式建立 Task（project / title / why / acceptance criteria / assignee） |
 
 ```bash
 # 在專案中安裝 Skill
 ct init-skill
 ```
 
-安裝後，在 Claude Code 中提到任何 issue（例如「幫我看 CT-42」），Claude 就會自動取得 issue 詳情並協助定位相關程式碼。
+`init-skill` 會以互動方式詢問要安裝哪些 skill（預設全選）與目標 agent（Claude Code / Codex / GitHub Copilot / 自訂路徑）。已存在的檔案不會在未確認下被覆寫。
+
+安裝後，在 Claude Code 提到任何 issue（如「幫我看 CT-42」）會啟動 analyzer；說「幫我建一張 task …」則由 create-task skill 引導你逐步建立。
 
 ### 設定方式
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@curl-ticket/cli",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "CLI tool for Curl Ticket — query issues and update status from your terminal",
   "keywords": [
     "api-debugging",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -22,6 +22,7 @@
   "files": [
     "dist",
     "skills",
+    "templates",
     "README.md",
     "LICENSE"
   ],

--- a/packages/cli/skills/curl-ticket-create-task/SKILL.md
+++ b/packages/cli/skills/curl-ticket-create-task/SKILL.md
@@ -1,0 +1,239 @@
+---
+name: curl-ticket-create-task
+description: >
+  Curl Ticket task creation tool. Guide the user through creating a structured Task
+  (## Why / ## Acceptance Criteria) by collecting project, title, why, acceptance
+  criteria, and assignee, then call `curl-ticket create-issue --type task --json`.
+  Trigger when: user says "create task", "新增 task", "add task", "open ticket as
+  task", "建立 task", "open a task", "create a ticket", "幫我開一張 task", or pastes
+  a PRD / requirement document and asks to file it as a task.
+  Do NOT use for analyzing existing issues or for `api_bug` cURL flows — use
+  `curl-ticket-issue-analyzer` for those.
+---
+
+# First-Run Introspection
+
+Before driving the flow:
+
+1. Run `curl-ticket schema` once to learn the current set of commands, exit codes,
+   and required fields. If the schema reports new required fields on
+   `create-issue --type task` that are not covered here, surface them in the
+   final preview before submitting.
+2. Run `curl-ticket projects --json` to discover available projects (used both to
+   resolve the Project answer and to fail fast when the user has none).
+
+# Mode Detection
+
+Pick one of two modes — **Step-by-step** or **Fast Path** — using a deterministic
+three-layer decision tree applied to the user's trigger message. Do not decide
+this freely; follow the layers in order.
+
+## Layer 1 — Explicit keyword override
+
+- Force **Fast Path** if the message contains any of:
+  `from this PRD`, `parse this`, `依這份`, `根據以下`, `直接建`, `skip questions`.
+- Force **Step-by-step** if the message contains any of:
+  `step by step`, `one by one`, `逐題`, `問我`.
+
+If a Layer 1 keyword matched, skip Layers 2–3.
+
+## Layer 2 — Structural signal
+
+If the message is two lines or fewer **and** contains no Markdown heading,
+no bullet list, and no token matching `[A-Z]+-\d+(\.\d+)*`, choose
+**Step-by-step**. Otherwise the message is a Fast Path **candidate** — proceed
+to Layer 3.
+
+## Layer 3 — Field extractability
+
+Run the Fast Path extraction rules below against the message:
+
+- `title`: first `#` / `##` Markdown heading text; fallback to the first sentence
+  truncated to 200 characters.
+- `why`: body of the first `## Why`, `## Background`, `## 動機`, or `## 為什麼`
+  section; fallback to the first non-heading paragraph.
+- `acceptance_criteria`: body of the first `## Acceptance Criteria`, `## AC`,
+  `## Done`, `## 驗收`, or `## Requirements` section; fallback to the first
+  bullet list found in the message.
+- `references` (optional): all unique tokens matching `[A-Z]+-\d+(\.\d+)*`,
+  preserving first-appearance order.
+
+Decision:
+
+- All three core fields (`title`, `why`, `acceptance_criteria`) extracted →
+  enter **Fast Path** and skip the per-field prompts for those three.
+- One or two of the three extracted → ask the user **once** via
+  `AskUserQuestion`: choose `Use auto-derived values` or `Ask me one by one`,
+  then proceed accordingly (Hybrid).
+- `title` or `why` cannot be extracted → fall back to **Step-by-step**, but
+  carry the pasted text as a hint inside each prompt so the user can copy from
+  it.
+
+## Project / Assignee are never auto-derived
+
+Regardless of the chosen mode:
+
+- **Project**: only skipped when `curl-ticket projects --json` returns exactly
+  one project. If the message contains a project key (e.g. `BA`) that maps
+  unambiguously to one of the listed projects, you may pre-select it but still
+  show the choice in the preview. Otherwise prompt as in Step-by-step.
+- **Assignee**: only auto-derived when the message contains `@<name>` or
+  `assign to <name>` / `指派給 <name>`. Otherwise prompt as in Step-by-step
+  (default `me`).
+
+# Question Flow (Step-by-step)
+
+Ask each question with a separate `AskUserQuestion` invocation, in this order.
+Do not bundle multiple questions into one prompt.
+
+## 1. Project
+
+Run `curl-ticket projects --json`.
+
+- 0 projects → stop and tell the user to create a project first
+  (e.g. `curl-ticket create-project --name ... --key ...`).
+- 1 project → skip this question; use that project's `id`.
+- ≥ 2 projects → ask `Which project?`, present each project as an option
+  labelled `<name> (<key>)` with the project `id` as the value. Allow a
+  free-form fallback so the user can paste a project ID directly.
+
+## 2. Title
+
+Open-ended. Trim whitespace. Reject empty strings or strings longer than
+200 characters and re-ask until valid.
+
+## 3. Why
+
+Open-ended. Suggest 1–3 sentences. An empty answer is allowed but the
+description will display `_(not provided)_`.
+
+## 4. Acceptance Criteria
+
+Open-ended, multiline. Hint: "one criterion per line; leading `- ` is
+optional". Normalise each non-empty line into a `- <line>` bullet, stripping
+any leading `- ` the user already typed. Empty input drops the section
+entirely.
+
+## 5. Assignee
+
+Open-ended, default `me`. Resolve using the same rules as
+`curl-ticket-issue-analyzer`:
+
+- empty answer or `me` → pass `--assignee me`
+- `none` / `null` → pass `--assignee none`
+- a UUID → pass through verbatim
+- an email → pass through verbatim
+- a natural-language name (e.g. `Alice`, `小明`) → first run
+  `curl-ticket members <projectId> --json`, match case-insensitively against
+  member `name` (fall back to email local-part):
+  - exact one match → pass that member's `email` (or `userId`) to `--assignee`
+  - multiple matches → list the candidates with their emails and ask the user
+    to confirm
+  - zero matches → tell the user no such member exists in the project and
+    re-ask
+
+# Description Template
+
+Assemble the issue description from this Markdown template. The canonical
+source is `packages/cli/src/templates/task.md` (shipped with the CLI as
+`templates/task.md`); the inline copy below is kept in sync.
+
+```
+## Why
+{{why}}
+
+## Acceptance Criteria
+{{acceptance_criteria}}
+
+## Notes
+{{notes}}
+
+## References
+{{references}}
+```
+
+Substitution rules:
+
+- `{{why}}` empty → replace with `_(not provided)_`.
+- `{{acceptance_criteria}}` empty → remove the entire section
+  (heading + body + the preceding blank line).
+- `{{notes}}` empty → remove the entire section as above.
+- `{{references}}` is rendered from the Fast Path requirement-ID list as
+  `- <ID>` bullets in first-appearance order. If the list is empty, remove the
+  section as above.
+
+# Preview / Confirm / Edit / Cancel Gate
+
+Before calling any mutating CLI command, show a preview and ask the user to
+choose one of `Confirm` / `Edit` / `Cancel` via `AskUserQuestion`.
+
+Preview format:
+
+```
+Title: <title>
+Project: <name> (<key>)
+Assignee: <resolved value>
+---
+<rendered description>
+---
+```
+
+Fast Path / Hybrid only — prefix the preview with
+`[Auto-derived from your message]` so the user can spot Agent-inferred values
+at a glance. After an `Edit` round-trip the marker disappears (the value is no
+longer purely auto-derived).
+
+`Edit` → ask which field to change
+(`Title` / `Why` / `Acceptance Criteria` / `Assignee` / `Project`), re-run
+only that question, then re-render the preview.
+
+`Cancel` → exit immediately without calling any CLI mutation.
+
+# CLI Invocation
+
+On `Confirm`, run:
+
+```bash
+curl-ticket create-issue <projectId> \
+  --type task \
+  --title "<title>" \
+  --description "<rendered description>" \
+  --assignee <resolved> \
+  --json
+```
+
+Example successful response:
+
+```json
+{
+  "data": { "id": 42, "issueNumber": 12, "title": "Add rate limiting", ... },
+  "friendlyId": "CT-12"
+}
+```
+
+Report back to the user the `friendlyId` and the issue URL constructed as
+`<site URL>/projects/<projectId>/issues/<id>` (the site URL is whatever the
+authenticated CLI is pointed at — derive it from the user's environment if
+already known; otherwise just print the `friendlyId` and instruct the user to
+open it in the web UI).
+
+# Error Handling
+
+Map CLI exit codes to user-facing guidance — do NOT retry automatically.
+
+| Exit code | Meaning                           | Action                                                               |
+| --------- | --------------------------------- | -------------------------------------------------------------------- |
+| 2         | Authentication / authorization    | Ask the user to run `curl-ticket auth login` (or check the token)    |
+| 3         | Resource not found (e.g. project) | Re-run `curl-ticket projects --json` and re-ask the project question |
+| 4         | Validation error                  | Surface the `message` field; offer to `Edit` the offending field     |
+| 5         | Network connection error          | Tell the user to check connectivity; offer to retry the same command |
+
+In `--json` mode the CLI returns errors as
+`{ "error": true, "code": <httpStatus>, "exitCode": <n>, "message": "..." }`.
+Read `exitCode` from that payload.
+
+# Cross-skill Reference
+
+This skill only **creates** tasks. For listing, analysing, updating status,
+assigning, or commenting on existing issues, the host should use
+`curl-ticket-issue-analyzer` instead.

--- a/packages/cli/skills/curl-ticket/SKILL.md
+++ b/packages/cli/skills/curl-ticket/SKILL.md
@@ -4,6 +4,8 @@ description: >
   Curl Ticket issue query and analysis tool. Fetch issue details via CLI, locate problematic code in the local codebase, and provide fix suggestions.
   Trigger when: user mentions issue, bug, ticket, error, Curl Ticket, CT- identifiers (e.g. CT-42),
   issue tracking, analyze bug, update issue status, or requests task information from the issue tracker.
+  Do NOT use this skill for *creating* a new task from a description / PRD —
+  that flow belongs to `curl-ticket-create-task`.
 ---
 
 # First-Run Introspection

--- a/packages/cli/src/__tests__/create-issue-mutex.test.ts
+++ b/packages/cli/src/__tests__/create-issue-mutex.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { createIssueCommand } from '../commands/create-issue.js'
+import { ValidationError } from '../utils.js'
+import type { CurlTicketClient } from '../api-client.js'
+
+const PROJECT_ID = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890'
+
+function noopClient(): CurlTicketClient {
+  return {
+    parseCurl: vi.fn(),
+    createIssue: vi.fn(),
+    getProjects: vi.fn(),
+    getMembers: vi.fn(),
+    getAuthMe: vi.fn()
+  } as unknown as CurlTicketClient
+}
+
+describe('createIssueCommand — mutex flags', () => {
+  let stdoutSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    stdoutSpy = vi.spyOn(process.stdout, 'write').mockReturnValue(true)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('rejects --interactive with --type api_bug', async () => {
+    await expect(
+      createIssueCommand(noopClient(), PROJECT_ID, { type: 'api_bug', interactive: true }, false)
+    ).rejects.toThrow(ValidationError)
+  })
+
+  it('rejects --interactive with --json', async () => {
+    await expect(
+      createIssueCommand(noopClient(), PROJECT_ID, { type: 'task', interactive: true }, true)
+    ).rejects.toThrow(/mutually exclusive/)
+  })
+
+  it('rejects --from-template with --description', async () => {
+    await expect(
+      createIssueCommand(
+        noopClient(),
+        PROJECT_ID,
+        { type: 'task', fromTemplate: 'task', description: 'hello' },
+        false
+      )
+    ).rejects.toThrow(/mutually exclusive/)
+  })
+
+  it('--from-template without --interactive prints rendered template and exits', async () => {
+    await createIssueCommand(
+      noopClient(),
+      PROJECT_ID,
+      { type: 'task', fromTemplate: 'task' },
+      false
+    )
+
+    const out = stdoutSpy.mock.calls.map((c: [string]) => c[0]).join('')
+    expect(out).toContain('## Why')
+    expect(out).toContain('_(not provided)_')
+    expect(out).not.toContain('## Acceptance Criteria')
+    expect(out).not.toContain('## Notes')
+    expect(out).not.toContain('{{')
+  })
+
+  it('rejects unknown template name', async () => {
+    await expect(
+      createIssueCommand(
+        noopClient(),
+        PROJECT_ID,
+        { type: 'task', fromTemplate: 'definitely-not-a-template' },
+        false
+      )
+    ).rejects.toThrow(/Unknown template/)
+  })
+})

--- a/packages/cli/src/__tests__/create-issue-validators.test.ts
+++ b/packages/cli/src/__tests__/create-issue-validators.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest'
+import {
+  validateTitle,
+  normalizeAcceptanceCriteria,
+  parseDescriptionSections,
+  extractRequirementIds
+} from '../commands/create-issue/validators.js'
+
+describe('validateTitle', () => {
+  it('rejects empty titles', () => {
+    expect(validateTitle('')).toMatch(/required/i)
+    expect(validateTitle('   ')).toMatch(/required/i)
+  })
+
+  it('rejects titles longer than 200 chars', () => {
+    expect(validateTitle('x'.repeat(201))).toMatch(/200/)
+  })
+
+  it('accepts titles in range', () => {
+    expect(validateTitle('A reasonable title')).toBe('')
+  })
+})
+
+describe('normalizeAcceptanceCriteria', () => {
+  it('strips leading "- " and re-bullets each non-empty line', () => {
+    expect(normalizeAcceptanceCriteria('- one\n  - two\nthree\n')).toBe('- one\n- two\n- three')
+  })
+
+  it('returns empty string for blank input', () => {
+    expect(normalizeAcceptanceCriteria('   \n\n')).toBe('')
+  })
+})
+
+describe('parseDescriptionSections', () => {
+  it('splits Why / Acceptance Criteria / Notes by heading', () => {
+    const md = `## Why\nbecause\n\n## Acceptance Criteria\n- a\n- b\n\n## Notes\nextra`
+    const sections = parseDescriptionSections(md)
+    expect(sections.why).toBe('because')
+    expect(sections.acceptanceCriteria).toBe('- a\n- b')
+    expect(sections.notes).toBe('extra')
+  })
+
+  it('treats unheaded prefix as the why bucket', () => {
+    const md = `something here\n\n## Acceptance Criteria\n- a`
+    const sections = parseDescriptionSections(md)
+    expect(sections.why).toContain('something here')
+    expect(sections.acceptanceCriteria).toBe('- a')
+  })
+
+  it('matches Chinese aliases (動機, 驗收, 備註)', () => {
+    const md = `## 動機\n為什麼\n\n## 驗收\n- ok\n\n## 備註\nextra`
+    const sections = parseDescriptionSections(md)
+    expect(sections.why).toBe('為什麼')
+    expect(sections.acceptanceCriteria).toBe('- ok')
+    expect(sections.notes).toBe('extra')
+  })
+})
+
+describe('extractRequirementIds', () => {
+  it('finds tokens matching [A-Z]+-\\d+(\\.\\d+)*', () => {
+    expect(extractRequirementIds('See AUTH-1, PERF-3.2 and AUTH-1 again.')).toEqual([
+      'AUTH-1',
+      'PERF-3.2'
+    ])
+  })
+
+  it('returns empty for no matches', () => {
+    expect(extractRequirementIds('plain text')).toEqual([])
+  })
+})

--- a/packages/cli/src/__tests__/init-skill.test.ts
+++ b/packages/cli/src/__tests__/init-skill.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest'
+import { SKILLS, getSkillById } from '../commands/init-skill/skills.js'
+import { AGENTS, targetPathFor } from '../commands/init-skill/agents.js'
+
+describe('init-skill manifest', () => {
+  it('exposes both bundled skills', () => {
+    const ids = SKILLS.map((s) => s.id)
+    expect(ids).toContain('curl-ticket')
+    expect(ids).toContain('curl-ticket-create-task')
+  })
+
+  it('looks up entries by id', () => {
+    expect(getSkillById('curl-ticket-create-task')?.label).toBe('curl-ticket-create-task')
+    expect(getSkillById('does-not-exist')).toBeUndefined()
+  })
+})
+
+describe('targetPathFor', () => {
+  it('builds <baseDir>/<skill>/SKILL.md for directory-style agents', () => {
+    const claude = AGENTS.find((a) => a.id === 'claude-code')!
+    expect(targetPathFor(claude, 'curl-ticket-create-task')).toBe(
+      '.claude/skills/curl-ticket-create-task/SKILL.md'
+    )
+  })
+
+  it('does not include cursor as a target agent', () => {
+    expect(AGENTS.find((a) => a.id === 'cursor')).toBeUndefined()
+  })
+})

--- a/packages/cli/src/__tests__/templates.test.ts
+++ b/packages/cli/src/__tests__/templates.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest'
+import { renderTemplateString } from '../templates/index.js'
+
+const SOURCE = `## Why
+{{why}}
+
+## Acceptance Criteria
+{{acceptance_criteria}}
+
+## Notes
+{{notes}}
+
+## References
+{{references}}
+`
+
+describe('renderTemplateString', () => {
+  it('substitutes all placeholders when every field is provided', () => {
+    const out = renderTemplateString(SOURCE, {
+      why: 'API is slow',
+      acceptance_criteria: ['p99 < 200ms', 'Errors < 0.1%'],
+      notes: 'Owner: backend',
+      references: ['AUTH-1', 'PERF-3.2']
+    })
+    expect(out).toContain('## Why\nAPI is slow')
+    expect(out).toContain('## Acceptance Criteria\n- p99 < 200ms\n- Errors < 0.1%')
+    expect(out).toContain('## Notes\nOwner: backend')
+    expect(out).toContain('## References\n- AUTH-1\n- PERF-3.2')
+  })
+
+  it('replaces empty why with _(not provided)_ marker', () => {
+    const out = renderTemplateString(SOURCE, {
+      why: '',
+      acceptance_criteria: ['x']
+    })
+    expect(out).toContain('## Why\n_(not provided)_')
+  })
+
+  it('drops Acceptance Criteria section entirely when empty', () => {
+    const out = renderTemplateString(SOURCE, {
+      why: 'because',
+      acceptance_criteria: ''
+    })
+    expect(out).not.toContain('## Acceptance Criteria')
+    expect(out).not.toContain('{{acceptance_criteria}}')
+  })
+
+  it('drops Notes section when empty', () => {
+    const out = renderTemplateString(SOURCE, { why: 'x', acceptance_criteria: ['a'], notes: '' })
+    expect(out).not.toContain('## Notes')
+  })
+
+  it('drops References section when empty', () => {
+    const out = renderTemplateString(SOURCE, {
+      why: 'x',
+      acceptance_criteria: ['a'],
+      references: []
+    })
+    expect(out).not.toContain('## References')
+  })
+
+  it('renders references as bullet list and dedupes preserving order', () => {
+    const out = renderTemplateString(SOURCE, {
+      why: 'x',
+      acceptance_criteria: ['a'],
+      references: ['AUTH-1', 'PERF-3', 'AUTH-1']
+    })
+    const refsBlock = out.split('## References')[1]
+    expect(refsBlock).toContain('- AUTH-1')
+    expect(refsBlock).toContain('- PERF-3')
+    expect(refsBlock!.match(/AUTH-1/g)).toHaveLength(1)
+  })
+
+  it('strips leading "- " from acceptance criteria lines and re-bullets', () => {
+    const out = renderTemplateString(SOURCE, {
+      why: 'x',
+      acceptance_criteria: '- one\n  - two\nthree'
+    })
+    expect(out).toContain('- one\n- two\n- three')
+  })
+
+  it('drops all optional sections at once', () => {
+    const out = renderTemplateString(SOURCE, { why: 'just because' })
+    expect(out).toContain('## Why\njust because')
+    expect(out).not.toContain('## Acceptance Criteria')
+    expect(out).not.toContain('## Notes')
+    expect(out).not.toContain('## References')
+    expect(out).not.toContain('{{')
+  })
+})

--- a/packages/cli/src/commands/create-issue.ts
+++ b/packages/cli/src/commands/create-issue.ts
@@ -148,11 +148,6 @@ function printResult(res: IssueResponse, json: boolean): void {
   console.log(`Issue created: ${res.friendlyId} — ${res.data.title}`)
 }
 
-/**
- * Render a registered template to stdout without touching auth or the network.
- * Shared between the CLI action handler (auth-skipping fast path) and
- * `createIssueCommand` (programmatic callers).
- */
 export async function printTemplate(name: string, description?: string): Promise<void> {
   if (description) {
     throw new ValidationError('--from-template and --description are mutually exclusive.')
@@ -201,7 +196,6 @@ export async function createIssueCommand(
     return
   }
 
-  // --- Non-interactive (legacy) paths ---
   if (!projectId) {
     throw new ValidationError('projectId is required.')
   }

--- a/packages/cli/src/commands/create-issue.ts
+++ b/packages/cli/src/commands/create-issue.ts
@@ -10,6 +10,8 @@ import {
   resolveAssignee,
   Prompter
 } from '../utils.js'
+import { renderTemplate } from '../templates/index.js'
+import { taskInteractiveFlow } from './create-issue/interactive.js'
 
 interface CreateIssueOptions {
   type?: string
@@ -19,6 +21,8 @@ interface CreateIssueOptions {
   env?: string
   status?: string
   assignee?: string
+  interactive?: boolean
+  fromTemplate?: string
 }
 
 const TITLE_MAX_LENGTH = 200
@@ -144,12 +148,63 @@ function printResult(res: IssueResponse, json: boolean): void {
   console.log(`Issue created: ${res.friendlyId} — ${res.data.title}`)
 }
 
+/**
+ * Render a registered template to stdout without touching auth or the network.
+ * Shared between the CLI action handler (auth-skipping fast path) and
+ * `createIssueCommand` (programmatic callers).
+ */
+export async function printTemplate(name: string, description?: string): Promise<void> {
+  if (description) {
+    throw new ValidationError('--from-template and --description are mutually exclusive.')
+  }
+  const rendered = await renderTemplate(name, {})
+  process.stdout.write(rendered)
+}
+
+function assertOptionsConsistent(options: CreateIssueOptions, json: boolean): void {
+  if (options.fromTemplate && options.description) {
+    throw new ValidationError('--from-template and --description are mutually exclusive.')
+  }
+  if (options.interactive && json) {
+    throw new ValidationError('--interactive and --json are mutually exclusive.')
+  }
+  if (options.interactive && options.type && normalizeType(options.type) !== 'task') {
+    throw new ValidationError('--interactive is only supported with --type task in v1.')
+  }
+}
+
 export async function createIssueCommand(
   client: CurlTicketClient,
-  projectId: string,
+  projectId: string | undefined,
   options: CreateIssueOptions,
   json = false
 ): Promise<void> {
+  assertOptionsConsistent(options, json)
+
+  if (options.fromTemplate && !options.interactive) {
+    await printTemplate(options.fromTemplate, options.description)
+    return
+  }
+
+  if (options.interactive) {
+    let descriptionFromTemplate: string | undefined
+    if (options.fromTemplate) {
+      descriptionFromTemplate = await renderTemplate(options.fromTemplate, {})
+    }
+    await taskInteractiveFlow(client, projectId, {
+      title: options.title,
+      description: options.description ?? descriptionFromTemplate,
+      assignee: options.assignee,
+      fromTemplate: options.fromTemplate,
+      status: options.status ? normalizeStatus(options.status) : undefined
+    })
+    return
+  }
+
+  // --- Non-interactive (legacy) paths ---
+  if (!projectId) {
+    throw new ValidationError('projectId is required.')
+  }
   validateProjectId(projectId)
 
   const prompter = process.stdin.isTTY ? new Prompter() : null

--- a/packages/cli/src/commands/create-issue/interactive.ts
+++ b/packages/cli/src/commands/create-issue/interactive.ts
@@ -1,0 +1,210 @@
+import { confirm, input, select } from '@inquirer/prompts'
+import type { CurlTicketClient } from '../../api-client.js'
+import type { CreateIssuePayload, IssueResponse } from '../../types.js'
+import { ValidationError, resolveAssignee, validateProjectId } from '../../utils.js'
+import {
+  assertValidTitle,
+  normalizeAcceptanceCriteria,
+  parseDescriptionSections,
+  validateTitle
+} from './validators.js'
+import { renderTemplate } from '../../templates/index.js'
+
+export interface TaskInteractiveOptions {
+  title?: string
+  description?: string
+  assignee?: string
+  fromTemplate?: string
+  status?: string
+}
+
+interface ProjectChoice {
+  id: string
+  label: string
+}
+
+interface Answers {
+  projectId: string
+  projectLabel: string
+  title: string
+  why: string
+  acceptanceCriteria: string
+  assignee: string
+}
+
+const FIELD_CHOICES = [
+  { name: 'Project', value: 'project' as const },
+  { name: 'Title', value: 'title' as const },
+  { name: 'Why', value: 'why' as const },
+  { name: 'Acceptance Criteria', value: 'acceptanceCriteria' as const },
+  { name: 'Assignee', value: 'assignee' as const }
+]
+
+async function loadProjects(client: CurlTicketClient): Promise<ProjectChoice[]> {
+  const res = await client.getProjects()
+  if (res.data.length === 0) {
+    throw new ValidationError(
+      'No projects available. Create one with `curl-ticket create-project`.'
+    )
+  }
+  return res.data.map((p) => ({ id: p.id, label: `${p.name} (${p.key})` }))
+}
+
+async function pickProject(
+  projects: ProjectChoice[],
+  providedId?: string,
+  currentId?: string
+): Promise<ProjectChoice> {
+  if (providedId) {
+    validateProjectId(providedId)
+    const matched = projects.find((p) => p.id === providedId)
+    return matched ?? { id: providedId, label: providedId }
+  }
+  if (projects.length === 1) {
+    return projects[0]
+  }
+  const chosenId = await select({
+    message: 'Which project?',
+    default: currentId,
+    choices: projects.map((p) => ({ name: p.label, value: p.id }))
+  })
+  return projects.find((p) => p.id === chosenId) ?? projects[0]
+}
+
+async function askTitle(defaultValue?: string): Promise<string> {
+  const answer = await input({
+    message: 'Title',
+    default: defaultValue,
+    required: true,
+    validate: (v) => {
+      const error = validateTitle(v)
+      return error === '' ? true : error
+    }
+  })
+  return answer.trim()
+}
+
+async function askWhy(defaultValue?: string): Promise<string> {
+  const answer = await input({
+    message: 'Why? (1–3 sentences; leave blank for none)',
+    default: defaultValue
+  })
+  return answer.trim()
+}
+
+async function askAcceptanceCriteria(defaultValue?: string): Promise<string> {
+  const answer = await input({
+    message: 'Acceptance Criteria (one per line, separated by ";"; blank to skip)',
+    default: defaultValue
+  })
+  // Allow `;` as a line separator since @inquirer/prompts input is single-line.
+  const normalized = answer.replace(/;\s*/g, '\n')
+  return normalizeAcceptanceCriteria(normalized)
+}
+
+async function askAssignee(defaultValue?: string): Promise<string> {
+  const answer = await input({
+    message: 'Assignee (me / none / <uuid> / <email>)',
+    default: defaultValue ?? 'me'
+  })
+  const trimmed = answer.trim()
+  return trimmed.length === 0 ? 'me' : trimmed
+}
+
+async function buildDescription(answers: Answers): Promise<string> {
+  return renderTemplate('task', {
+    why: answers.why,
+    acceptance_criteria: answers.acceptanceCriteria
+  })
+}
+
+function renderPreview(answers: Answers, description: string): string {
+  return [
+    '--- Preview ---',
+    `Project: ${answers.projectLabel}`,
+    `Title: ${answers.title}`,
+    `Assignee: ${answers.assignee}`,
+    '---',
+    description.trimEnd(),
+    '--- End Preview ---'
+  ].join('\n')
+}
+
+export async function taskInteractiveFlow(
+  client: CurlTicketClient,
+  projectIdArg: string | undefined,
+  options: TaskInteractiveOptions
+): Promise<void> {
+  const projects = await loadProjects(client)
+  const initialProject = await pickProject(projects, projectIdArg)
+
+  const prefilled = options.description
+    ? parseDescriptionSections(options.description)
+    : { why: '', acceptanceCriteria: '', notes: '' }
+
+  const answers: Answers = {
+    projectId: initialProject.id,
+    projectLabel: initialProject.label,
+    title: await askTitle(options.title),
+    why: await askWhy(prefilled.why),
+    acceptanceCriteria: await askAcceptanceCriteria(prefilled.acceptanceCriteria),
+    assignee: await askAssignee(options.assignee)
+  }
+
+  while (true) {
+    const description = await buildDescription(answers)
+    process.stderr.write(renderPreview(answers, description) + '\n')
+
+    const action = await select<'confirm' | 'edit' | 'cancel'>({
+      message: 'Create this task?',
+      choices: [
+        { name: 'Confirm', value: 'confirm' },
+        { name: 'Edit a field', value: 'edit' },
+        { name: 'Cancel', value: 'cancel' }
+      ]
+    })
+
+    if (action === 'cancel') {
+      process.stderr.write('Cancelled.\n')
+      return
+    }
+
+    if (action === 'edit') {
+      const field = await select({ message: 'Which field?', choices: FIELD_CHOICES })
+      if (field === 'project') {
+        const next = await pickProject(projects, undefined, answers.projectId)
+        answers.projectId = next.id
+        answers.projectLabel = next.label
+      } else if (field === 'title') answers.title = await askTitle(answers.title)
+      else if (field === 'why') answers.why = await askWhy(answers.why)
+      else if (field === 'acceptanceCriteria') {
+        answers.acceptanceCriteria = await askAcceptanceCriteria(answers.acceptanceCriteria)
+      } else if (field === 'assignee') answers.assignee = await askAssignee(answers.assignee)
+      continue
+    }
+
+    // Confirmed — submit
+    assertValidTitle(answers.title)
+    const assigneeId = await resolveAssignee({
+      value: answers.assignee,
+      projectId: answers.projectId,
+      client
+    })
+
+    const payload: CreateIssuePayload = {
+      issueType: 'task',
+      title: answers.title,
+      description,
+      ...(options.status && { status: options.status }),
+      assigneeId
+    }
+
+    const res: IssueResponse = await client.createIssue(answers.projectId, payload)
+    const ok = await confirm({ message: 'Done. Show JSON?', default: false }).catch(() => false)
+    if (ok) {
+      process.stderr.write(JSON.stringify(res, null, 2) + '\n')
+    }
+    console.log(`Issue created: ${res.friendlyId} — ${res.data.title}`)
+    return
+  }
+}

--- a/packages/cli/src/commands/create-issue/interactive.ts
+++ b/packages/cli/src/commands/create-issue/interactive.ts
@@ -111,13 +111,6 @@ async function askAssignee(defaultValue?: string): Promise<string> {
   return trimmed.length === 0 ? 'me' : trimmed
 }
 
-async function buildDescription(answers: Answers): Promise<string> {
-  return renderTemplate('task', {
-    why: answers.why,
-    acceptance_criteria: answers.acceptanceCriteria
-  })
-}
-
 function renderPreview(answers: Answers, description: string): string {
   return [
     '--- Preview ---',
@@ -151,8 +144,31 @@ export async function taskInteractiveFlow(
     assignee: await askAssignee(options.assignee)
   }
 
+  const fieldEditors: Record<(typeof FIELD_CHOICES)[number]['value'], () => Promise<void>> = {
+    project: async () => {
+      const next = await pickProject(projects, undefined, answers.projectId)
+      answers.projectId = next.id
+      answers.projectLabel = next.label
+    },
+    title: async () => {
+      answers.title = await askTitle(answers.title)
+    },
+    why: async () => {
+      answers.why = await askWhy(answers.why)
+    },
+    acceptanceCriteria: async () => {
+      answers.acceptanceCriteria = await askAcceptanceCriteria(answers.acceptanceCriteria)
+    },
+    assignee: async () => {
+      answers.assignee = await askAssignee(answers.assignee)
+    }
+  }
+
   while (true) {
-    const description = await buildDescription(answers)
+    const description = await renderTemplate('task', {
+      why: answers.why,
+      acceptance_criteria: answers.acceptanceCriteria
+    })
     process.stderr.write(renderPreview(answers, description) + '\n')
 
     const action = await select<'confirm' | 'edit' | 'cancel'>({
@@ -171,19 +187,10 @@ export async function taskInteractiveFlow(
 
     if (action === 'edit') {
       const field = await select({ message: 'Which field?', choices: FIELD_CHOICES })
-      if (field === 'project') {
-        const next = await pickProject(projects, undefined, answers.projectId)
-        answers.projectId = next.id
-        answers.projectLabel = next.label
-      } else if (field === 'title') answers.title = await askTitle(answers.title)
-      else if (field === 'why') answers.why = await askWhy(answers.why)
-      else if (field === 'acceptanceCriteria') {
-        answers.acceptanceCriteria = await askAcceptanceCriteria(answers.acceptanceCriteria)
-      } else if (field === 'assignee') answers.assignee = await askAssignee(answers.assignee)
+      await fieldEditors[field]()
       continue
     }
 
-    // Confirmed — submit
     assertValidTitle(answers.title)
     const assigneeId = await resolveAssignee({
       value: answers.assignee,

--- a/packages/cli/src/commands/create-issue/validators.ts
+++ b/packages/cli/src/commands/create-issue/validators.ts
@@ -1,0 +1,93 @@
+import { ValidationError } from '../../utils.js'
+import { bulletize } from '../../templates/index.js'
+
+export const TITLE_MAX_LENGTH = 200
+
+export function validateTitle(value: string): string {
+  const trimmed = value.trim()
+  if (trimmed.length === 0) return 'Title is required.'
+  if (trimmed.length > TITLE_MAX_LENGTH) {
+    return `Title cannot exceed ${TITLE_MAX_LENGTH} characters.`
+  }
+  return ''
+}
+
+export function assertValidTitle(value: string): string {
+  const error = validateTitle(value)
+  if (error) throw new ValidationError(error)
+  return value.trim()
+}
+
+export function normalizeAcceptanceCriteria(value: string): string {
+  return bulletize(value)
+}
+
+interface DescriptionSections {
+  why: string
+  acceptanceCriteria: string
+  notes: string
+}
+
+/**
+ * Split a Markdown description into Why / Acceptance Criteria / Notes sections.
+ * Unmatched headings fall through to the section currently being collected;
+ * whatever appears before any `## ` heading is treated as the "why" body.
+ */
+export function parseDescriptionSections(markdown: string): DescriptionSections {
+  const sections: DescriptionSections = { why: '', acceptanceCriteria: '', notes: '' }
+  const lines = markdown.split('\n')
+  let current: keyof DescriptionSections = 'why'
+  const buffers: Record<keyof DescriptionSections, string[]> = {
+    why: [],
+    acceptanceCriteria: [],
+    notes: []
+  }
+
+  for (const line of lines) {
+    const heading = line.match(/^##\s+(.+?)\s*$/)
+    if (heading) {
+      const name = heading[1].toLowerCase()
+      if (name === 'why' || name === 'background' || name === '動機' || name === '為什麼') {
+        current = 'why'
+        continue
+      }
+      if (
+        name === 'acceptance criteria' ||
+        name === 'ac' ||
+        name === 'done' ||
+        name === '驗收' ||
+        name === 'requirements'
+      ) {
+        current = 'acceptanceCriteria'
+        continue
+      }
+      if (name === 'notes' || name === 'note' || name === '備註') {
+        current = 'notes'
+        continue
+      }
+      // Unknown heading — keep it in the current bucket as raw content
+      buffers[current].push(line)
+      continue
+    }
+    buffers[current].push(line)
+  }
+
+  sections.why = buffers.why.join('\n').trim()
+  sections.acceptanceCriteria = buffers.acceptanceCriteria.join('\n').trim()
+  sections.notes = buffers.notes.join('\n').trim()
+  return sections
+}
+
+export function extractRequirementIds(text: string): string[] {
+  const re = /\b[A-Z]+-\d+(?:\.\d+)*\b/g
+  const seen = new Set<string>()
+  const out: string[] = []
+  for (const match of text.matchAll(re)) {
+    const id = match[0]
+    if (!seen.has(id)) {
+      seen.add(id)
+      out.push(id)
+    }
+  }
+  return out
+}

--- a/packages/cli/src/commands/init-skill/agents.ts
+++ b/packages/cli/src/commands/init-skill/agents.ts
@@ -1,9 +1,10 @@
-export type SkillFormat = 'skill-md' | 'cursor-mdc' | 'plain-md'
+export type SkillFormat = 'skill-md' | 'plain-md'
 
 export interface AgentConfig {
   id: string
   label: string
-  targetPath: string
+  /** Directory under `cwd` where each skill lives in its own `<skill>/SKILL.md`. */
+  baseDir: string
   format: SkillFormat
   postInstallHints: string[]
 }
@@ -12,7 +13,7 @@ export const AGENTS: AgentConfig[] = [
   {
     id: 'claude-code',
     label: 'Claude Code',
-    targetPath: '.claude/skills/curl-ticket/SKILL.md',
+    baseDir: '.claude/skills',
     format: 'skill-md',
     postInstallHints: [
       'Make sure .claude/settings.json permissions.allow includes:',
@@ -22,22 +23,19 @@ export const AGENTS: AgentConfig[] = [
   {
     id: 'codex',
     label: 'Codex (OpenAI)',
-    targetPath: '.agents/skills/curl-ticket/SKILL.md',
+    baseDir: '.agents/skills',
     format: 'skill-md',
     postInstallHints: ['Codex automatically detects skill files in .agents/skills/.']
   },
   {
     id: 'copilot',
     label: 'GitHub Copilot',
-    targetPath: '.github/skills/curl-ticket/SKILL.md',
+    baseDir: '.github/skills',
     format: 'skill-md',
     postInstallHints: ['Copilot automatically detects skill files in .github/skills/.']
-  },
-  {
-    id: 'cursor',
-    label: 'Cursor',
-    targetPath: '.cursor/rules/curl-ticket.mdc',
-    format: 'cursor-mdc',
-    postInstallHints: ['Cursor automatically loads rule files from .cursor/rules/.']
   }
 ]
+
+export function targetPathFor(agent: AgentConfig, skillId: string): string {
+  return `${agent.baseDir}/${skillId}/SKILL.md`
+}

--- a/packages/cli/src/commands/init-skill/file-ops.ts
+++ b/packages/cli/src/commands/init-skill/file-ops.ts
@@ -14,16 +14,19 @@ export async function fileExists(path: string): Promise<boolean> {
   }
 }
 
-export async function readSourceSkill(): Promise<string> {
-  // Source skill file is bundled alongside dist/
-  // In the npm package: skills/curl-ticket/SKILL.md
-  // Relative to dist/index.js: ../skills/curl-ticket/SKILL.md
-  const sourceFile = join(__dirname, '..', 'skills', 'curl-ticket', 'SKILL.md')
-
+/**
+ * Resolve a skill source file from the installed package layout:
+ *   <packageRoot>/skills/<skillId>/SKILL.md
+ * Relative to dist/index.js, that is `../skills/<skillId>/SKILL.md`.
+ */
+export async function readSkillSource(skillId: string): Promise<string> {
+  const sourceFile = join(__dirname, '..', 'skills', skillId, 'SKILL.md')
   try {
     return await readFile(sourceFile, 'utf-8')
   } catch {
-    throw new Error('Skill file not found. Please verify the CLI installation is complete.')
+    throw new Error(
+      `Skill source for "${skillId}" not found. Verify the CLI installation is complete.`
+    )
   }
 }
 

--- a/packages/cli/src/commands/init-skill/index.ts
+++ b/packages/cli/src/commands/init-skill/index.ts
@@ -1,47 +1,59 @@
 import { join } from 'node:path'
-import { AGENTS } from './agents.js'
+import { AGENTS, targetPathFor, type AgentConfig } from './agents.js'
+import { SKILLS } from './skills.js'
 import { askCheckbox, askConfirm, askText } from './prompts.js'
 import { transformContent } from './transform.js'
-import { fileExists, readSourceSkill, writeSkillFile } from './file-ops.js'
+import { fileExists, readSkillSource, writeSkillFile } from './file-ops.js'
 
-interface Target {
+interface ResolvedTarget {
+  skillId: string
+  agent: AgentConfig | null
   path: string
-  format: 'skill-md' | 'cursor-mdc' | 'plain-md'
   hints: string[]
 }
 
 export async function initSkillCommand(): Promise<void> {
-  const sourceContent = await readSourceSkill()
+  // 1. Pick skills (default: all).
+  const skillChoices = SKILLS.map((s, i) => ({
+    name: `${s.label.padEnd(34)} — ${s.description}`,
+    value: i,
+    checked: true
+  }))
+  const selectedSkillIdx = await askCheckbox('Select skill(s) to install:', skillChoices)
+  const selectedSkills = selectedSkillIdx.map((i) => SKILLS[i])
 
-  const choices = [
+  // 2. Pick agents (one or more), or a custom path.
+  const agentChoices = [
     ...AGENTS.map((a, i) => ({
-      name: `${a.label.padEnd(20)} → ${a.targetPath}`,
+      name: `${a.label.padEnd(20)} → ${a.baseDir}`,
       value: i
     })),
     { name: 'Custom path', value: AGENTS.length }
   ]
+  const selectedAgentIdx = await askCheckbox('Select your coding agent(s):', agentChoices)
 
-  const selected = await askCheckbox('Select your coding agent(s):', choices)
-
-  const targets: Target[] = []
-
-  for (const idx of selected) {
-    if (idx < AGENTS.length) {
-      const agent = AGENTS[idx]
-      targets.push({
-        path: join(process.cwd(), agent.targetPath),
-        format: agent.format,
-        hints: agent.postInstallHints
-      })
-    } else {
-      const customPath = await askText(
-        'Enter target file path (e.g. .windsurf/skills/curl-ticket/SKILL.md):'
-      )
-      targets.push({
-        path: join(process.cwd(), customPath),
-        format: 'plain-md',
-        hints: []
-      })
+  const targets: ResolvedTarget[] = []
+  for (const skill of selectedSkills) {
+    for (const idx of selectedAgentIdx) {
+      if (idx < AGENTS.length) {
+        const agent = AGENTS[idx]
+        targets.push({
+          skillId: skill.id,
+          agent,
+          path: join(process.cwd(), targetPathFor(agent, skill.id)),
+          hints: agent.postInstallHints
+        })
+      } else {
+        const customPath = await askText(
+          `Enter target file path for "${skill.label}" (e.g. .foo/skills/${skill.id}/SKILL.md):`
+        )
+        targets.push({
+          skillId: skill.id,
+          agent: null,
+          path: join(process.cwd(), customPath),
+          hints: []
+        })
+      }
     }
   }
 
@@ -54,7 +66,9 @@ export async function initSkillCommand(): Promise<void> {
       }
     }
 
-    const content = transformContent(sourceContent, target.format)
+    const source = await readSkillSource(target.skillId)
+    const format = target.agent?.format ?? 'plain-md'
+    const content = transformContent(source, format)
     await writeSkillFile(target.path, content)
     console.log(`Created ${target.path}`)
 

--- a/packages/cli/src/commands/init-skill/index.ts
+++ b/packages/cli/src/commands/init-skill/index.ts
@@ -57,6 +57,16 @@ export async function initSkillCommand(): Promise<void> {
     }
   }
 
+  const sourceCache = new Map<string, string>()
+  const loadSource = async (skillId: string): Promise<string> => {
+    let cached = sourceCache.get(skillId)
+    if (cached === undefined) {
+      cached = await readSkillSource(skillId)
+      sourceCache.set(skillId, cached)
+    }
+    return cached
+  }
+
   for (const target of targets) {
     if (await fileExists(target.path)) {
       const overwrite = await askConfirm(`${target.path} already exists. Overwrite?`)
@@ -66,7 +76,7 @@ export async function initSkillCommand(): Promise<void> {
       }
     }
 
-    const source = await readSkillSource(target.skillId)
+    const source = await loadSource(target.skillId)
     const format = target.agent?.format ?? 'plain-md'
     const content = transformContent(source, format)
     await writeSkillFile(target.path, content)

--- a/packages/cli/src/commands/init-skill/skills.ts
+++ b/packages/cli/src/commands/init-skill/skills.ts
@@ -1,0 +1,25 @@
+export interface SkillManifestEntry {
+  /** Directory name under `<packageRoot>/skills/` and target subdirectory name. */
+  id: string
+  /** Display label shown in selection prompts. */
+  label: string
+  /** One-line summary surfaced in selection prompts and docs. */
+  description: string
+}
+
+export const SKILLS: SkillManifestEntry[] = [
+  {
+    id: 'curl-ticket',
+    label: 'curl-ticket-issue-analyzer',
+    description: 'Query and analyze existing issues, locate problematic code, suggest fixes'
+  },
+  {
+    id: 'curl-ticket-create-task',
+    label: 'curl-ticket-create-task',
+    description: 'Guided interactive task creation (project / title / why / AC / assignee)'
+  }
+]
+
+export function getSkillById(id: string): SkillManifestEntry | undefined {
+  return SKILLS.find((s) => s.id === id)
+}

--- a/packages/cli/src/commands/init-skill/transform.ts
+++ b/packages/cli/src/commands/init-skill/transform.ts
@@ -15,7 +15,6 @@ function parseFrontmatter(source: string): ParsedSkill {
   const body = match[2]
   const frontmatter: Record<string, string> = {}
 
-  // Parse simple YAML key-value pairs (supports multi-line values with >)
   let currentKey = ''
   let currentValue = ''
 
@@ -39,18 +38,6 @@ function parseFrontmatter(source: string): ParsedSkill {
   return { frontmatter, body }
 }
 
-function toCursorMdc(source: string): string {
-  const { frontmatter, body } = parseFrontmatter(source)
-  const description = frontmatter.description || ''
-
-  return `---
-description: "${description}"
-globs:
-alwaysApply: true
----
-${body}`
-}
-
 function toPlainMd(source: string): string {
   const { body } = parseFrontmatter(source)
   return body.startsWith('\n') ? body.slice(1) : body
@@ -60,8 +47,6 @@ export function transformContent(source: string, format: SkillFormat): string {
   switch (format) {
     case 'skill-md':
       return source
-    case 'cursor-mdc':
-      return toCursorMdc(source)
     case 'plain-md':
       return toPlainMd(source)
   }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -22,7 +22,7 @@ import { projectCommand } from './commands/project.js'
 import { createProjectCommand } from './commands/create-project.js'
 import { membersCommand } from './commands/members.js'
 import { deleteIssueCommand } from './commands/delete-issue.js'
-import { createIssueCommand } from './commands/create-issue.js'
+import { createIssueCommand, printTemplate } from './commands/create-issue.js'
 import { assignCommand } from './commands/assign.js'
 import { myIssuesCommand } from './commands/my-issues.js'
 import { schemaCommand } from './commands/schema.js'
@@ -257,11 +257,8 @@ program
       }
     ) => {
       try {
-        // Print-only template mode short-circuits before withAuth() so that
-        // unauthenticated users can still render the template. The same mutex
-        // checks live inside createIssueCommand for direct/programmatic callers.
+        // Skip auth when only printing a template — no network call needed.
         if (options.fromTemplate && !options.interactive) {
-          const { printTemplate } = await import('./commands/create-issue.js')
           await printTemplate(options.fromTemplate, options.description)
           return
         }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -224,7 +224,7 @@ program
   })
 
 program
-  .command('create-issue <projectId>')
+  .command('create-issue [projectId]')
   .description('Create a new issue')
   .option('-t, --type <type>', 'Issue type (api_bug / task)')
   .option('--curl <curl>', 'Raw cURL command string (required for api_bug)')
@@ -236,9 +236,14 @@ program
   )
   .option('--status <status>', 'Initial status (Open / in-progress / Done / Close)')
   .option('--assignee <value>', 'Assignee (me / none / <uuid> / <email>)')
+  .option('-i, --interactive', 'Drive a guided 5-step task creation flow (task only)')
+  .option(
+    '--from-template <name>',
+    'Use a registered description template (e.g. task). Without --interactive, prints the template and exits.'
+  )
   .action(
     async (
-      projectId: string,
+      projectId: string | undefined,
       options: {
         type?: string
         curl?: string
@@ -247,9 +252,19 @@ program
         env?: string
         status?: string
         assignee?: string
+        interactive?: boolean
+        fromTemplate?: string
       }
     ) => {
       try {
+        // Print-only template mode short-circuits before withAuth() so that
+        // unauthenticated users can still render the template. The same mutex
+        // checks live inside createIssueCommand for direct/programmatic callers.
+        if (options.fromTemplate && !options.interactive) {
+          const { printTemplate } = await import('./commands/create-issue.js')
+          await printTemplate(options.fromTemplate, options.description)
+          return
+        }
         await withAuth((client) => createIssueCommand(client, projectId, options, isJsonMode()))
       } catch (err) {
         handleError(err, isJsonMode())

--- a/packages/cli/src/templates/index.ts
+++ b/packages/cli/src/templates/index.ts
@@ -1,0 +1,144 @@
+import { readFile, readdir } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = dirname(__filename)
+
+// In the published package the bundled file lives at <packageRoot>/dist/index.js,
+// so templates resolve as `<__dirname>/../templates`. When running from source
+// (vitest, ts-node), `__dirname` is `<packageRoot>/src/templates`, so we need
+// `<__dirname>/../../templates`. Probe both.
+const TEMPLATE_DIR_CANDIDATES = [
+  join(__dirname, '..', 'templates'),
+  join(__dirname, '..', '..', 'templates')
+]
+
+const WHY_EMPTY_PLACEHOLDER = '_(not provided)_'
+
+export interface RenderVars {
+  why?: string
+  acceptance_criteria?: string | string[]
+  notes?: string
+  references?: string | string[]
+}
+
+export async function listTemplates(): Promise<string[]> {
+  for (const dir of TEMPLATE_DIR_CANDIDATES) {
+    try {
+      const entries = await readdir(dir)
+      const md = entries.filter((f) => f.endsWith('.md'))
+      if (md.length > 0) return md.map((f) => f.slice(0, -3))
+    } catch {
+      // try next candidate
+    }
+  }
+  return []
+}
+
+export async function loadTemplate(name: string): Promise<string> {
+  for (const dir of TEMPLATE_DIR_CANDIDATES) {
+    try {
+      return await readFile(join(dir, `${name}.md`), 'utf-8')
+    } catch {
+      // try next candidate
+    }
+  }
+  const available = await listTemplates()
+  throw new TemplateNotFoundError(name, available)
+}
+
+export class TemplateNotFoundError extends Error {
+  constructor(
+    public name: string,
+    public available: string[]
+  ) {
+    super(
+      available.length > 0
+        ? `Unknown template "${name}". Available: ${available.join(', ')}.`
+        : `Unknown template "${name}". No templates are currently registered.`
+    )
+    this.name = 'TemplateNotFoundError'
+  }
+}
+
+export function bulletize(value: string | string[]): string {
+  const lines = Array.isArray(value)
+    ? value
+    : value
+        .split('\n')
+        .map((l) => l.replace(/^\s*-\s*/, ''))
+        .map((l) => l.trim())
+  const items = lines.map((l) => l.trim()).filter((l) => l.length > 0)
+  return items.map((l) => `- ${l}`).join('\n')
+}
+
+function isEmpty(value: string | string[] | undefined): boolean {
+  if (value == null) return true
+  if (Array.isArray(value)) return value.filter((v) => v.trim().length > 0).length === 0
+  return value.trim().length === 0
+}
+
+function dropSection(template: string, heading: string): string {
+  const lines = template.split('\n')
+  const startIdx = lines.findIndex((l) => l.trim() === `## ${heading}`)
+  if (startIdx === -1) return template
+  let endIdx = lines.length
+  for (let i = startIdx + 1; i < lines.length; i++) {
+    if (lines[i].startsWith('## ')) {
+      endIdx = i
+      break
+    }
+  }
+  let removeFrom = startIdx
+  while (removeFrom > 0 && lines[removeFrom - 1].trim() === '') {
+    removeFrom -= 1
+  }
+  return [...lines.slice(0, removeFrom), ...lines.slice(endIdx)].join('\n')
+}
+
+export function renderTemplateString(source: string, vars: RenderVars): string {
+  let out = source
+
+  // Drop empty optional sections first so we don't leave dangling placeholders.
+  if (isEmpty(vars.acceptance_criteria)) {
+    out = dropSection(out, 'Acceptance Criteria')
+  } else {
+    out = out.replace('{{acceptance_criteria}}', bulletize(vars.acceptance_criteria!))
+  }
+
+  if (isEmpty(vars.notes)) {
+    out = dropSection(out, 'Notes')
+  } else {
+    out = out.replace('{{notes}}', vars.notes!.trim())
+  }
+
+  if (isEmpty(vars.references)) {
+    out = dropSection(out, 'References')
+  } else {
+    const refs = Array.isArray(vars.references)
+      ? vars.references
+      : vars
+          .references!.split(/\s+/)
+          .map((s) => s.trim())
+          .filter(Boolean)
+    const seen = new Set<string>()
+    const unique = refs.filter((r) => {
+      if (seen.has(r)) return false
+      seen.add(r)
+      return true
+    })
+    out = out.replace('{{references}}', unique.map((r) => `- ${r}`).join('\n'))
+  }
+
+  // why: empty becomes a placeholder marker (section is preserved).
+  const why = isEmpty(vars.why) ? WHY_EMPTY_PLACEHOLDER : vars.why!.trim()
+  out = out.replace('{{why}}', why)
+
+  return out.replace(/\n{3,}/g, '\n\n').replace(/\s+$/, '') + '\n'
+}
+
+export async function renderTemplate(name: string, vars: RenderVars): Promise<string> {
+  const source = await loadTemplate(name)
+  return renderTemplateString(source, vars)
+}

--- a/packages/cli/src/templates/index.ts
+++ b/packages/cli/src/templates/index.ts
@@ -36,10 +36,16 @@ export async function listTemplates(): Promise<string[]> {
   return []
 }
 
+const templateCache = new Map<string, string>()
+
 export async function loadTemplate(name: string): Promise<string> {
+  const cached = templateCache.get(name)
+  if (cached !== undefined) return cached
   for (const dir of TEMPLATE_DIR_CANDIDATES) {
     try {
-      return await readFile(join(dir, `${name}.md`), 'utf-8')
+      const content = await readFile(join(dir, `${name}.md`), 'utf-8')
+      templateCache.set(name, content)
+      return content
     } catch {
       // try next candidate
     }

--- a/packages/cli/templates/task.md
+++ b/packages/cli/templates/task.md
@@ -1,0 +1,15 @@
+## Why
+
+{{why}}
+
+## Acceptance Criteria
+
+{{acceptance_criteria}}
+
+## Notes
+
+{{notes}}
+
+## References
+
+{{references}}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,12 @@ importers:
       drizzle-orm:
         specifier: ^0.45.1
         version: 0.45.1(postgres@3.4.8)
+      isomorphic-dompurify:
+        specifier: ^3.10.0
+        version: 3.10.0
+      markdown-it:
+        specifier: ^14.1.1
+        version: 14.1.1
       nuxt:
         specifier: ^4.2.2
         version: 4.2.2(@parcel/watcher@2.5.4)(@types/node@25.4.0)(@vue/compiler-sfc@3.5.27)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4(drizzle-orm@0.45.1(postgres@3.4.8)))(drizzle-orm@0.45.1(postgres@3.4.8))(eslint@10.1.0(jiti@2.6.1))(ioredis@5.9.2)(lightningcss@1.31.1)(magicast@0.5.1)(optionator@0.9.4)(oxlint@1.57.0)(rollup@4.55.3)(terser@5.46.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(yaml@2.8.2))(vue-tsc@3.2.4(typescript@5.9.3))(yaml@2.8.2)
@@ -63,12 +69,18 @@ importers:
       '@stylistic/eslint-plugin':
         specifier: ^5.10.0
         version: 5.10.0(eslint@10.1.0(jiti@2.6.1))
+      '@tailwindcss/typography':
+        specifier: ^0.5.19
+        version: 0.5.19(tailwindcss@4.1.18)
+      '@types/markdown-it':
+        specifier: ^14.1.2
+        version: 14.1.2
       '@types/sanitize-html':
         specifier: ^2.16.1
         version: 2.16.1
       '@vitest/coverage-v8':
         specifier: ^4.0.18
-        version: 4.0.18(vitest@4.0.18(@types/node@25.4.0)(jiti@2.6.1)(jsdom@29.0.1)(lightningcss@1.31.1)(terser@5.46.0)(yaml@2.8.2))
+        version: 4.0.18(vitest@4.0.18(@types/node@25.4.0)(jiti@2.6.1)(jsdom@29.1.0)(lightningcss@1.31.1)(terser@5.46.0)(yaml@2.8.2))
       agent-browser:
         specifier: ^0.13.0
         version: 0.13.0
@@ -95,7 +107,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.18
-        version: 4.0.18(@types/node@25.4.0)(jiti@2.6.1)(jsdom@29.0.1)(lightningcss@1.31.1)(terser@5.46.0)(yaml@2.8.2)
+        version: 4.0.18(@types/node@25.4.0)(jiti@2.6.1)(jsdom@29.1.0)(lightningcss@1.31.1)(terser@5.46.0)(yaml@2.8.2)
       vue-tsc:
         specifier: ^3.2.4
         version: 3.2.4(typescript@5.9.3)
@@ -132,12 +144,16 @@ packages:
     resolution: {integrity: sha512-9C2o9X/lBEDBUnKfAi3mRo9oG7Z03nmISLwsGkWxIWjMAvBdJD0RRSJMekWVKzfXN3byrI1WlCXTITzN4LAoLw==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0, npm: '>=8'}
 
-  '@asamuzakjp/css-color@5.0.1':
-    resolution: {integrity: sha512-2SZFvqMyvboVV1d15lMf7XiI3m7SDqXUuKaTymJYLN6dSGadqp+fVojqJlVoMlbZnlTmu3S0TLwLTJpvBMO1Aw==}
+  '@asamuzakjp/css-color@5.1.11':
+    resolution: {integrity: sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
-  '@asamuzakjp/dom-selector@7.0.3':
-    resolution: {integrity: sha512-Q6mU0Z6bfj6YvnX2k9n0JxiIwrCFN59x/nWmYQnAqP000ruX/yV+5bp/GRcF5T8ncvfwJQ7fgfP74DlpKExILA==}
+  '@asamuzakjp/dom-selector@7.1.1':
+    resolution: {integrity: sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/generational-cache@1.0.1':
+    resolution: {integrity: sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   '@asamuzakjp/nwsapi@2.3.9':
@@ -301,15 +317,15 @@ packages:
     resolution: {integrity: sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==}
     engines: {node: '>=20.19.0'}
 
-  '@csstools/css-calc@3.1.1':
-    resolution: {integrity: sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==}
+  '@csstools/css-calc@3.2.0':
+    resolution: {integrity: sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==}
     engines: {node: '>=20.19.0'}
     peerDependencies:
       '@csstools/css-parser-algorithms': ^4.0.0
       '@csstools/css-tokenizer': ^4.0.0
 
-  '@csstools/css-color-parser@4.0.2':
-    resolution: {integrity: sha512-0GEfbBLmTFf0dJlpsNU7zwxRIH0/BGEMuXLTCvFYxuL1tNhqzTbtnFICyJLTNK4a+RechKP75e7w42ClXSnJQw==}
+  '@csstools/css-color-parser@4.1.0':
+    resolution: {integrity: sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==}
     engines: {node: '>=20.19.0'}
     peerDependencies:
       '@csstools/css-parser-algorithms': ^4.0.0
@@ -321,8 +337,8 @@ packages:
     peerDependencies:
       '@csstools/css-tokenizer': ^4.0.0
 
-  '@csstools/css-syntax-patches-for-csstree@1.1.1':
-    resolution: {integrity: sha512-BvqN0AMWNAnLk9G8jnUT77D+mUbY/H2b3uDTvg2isJkHaOufUE2R3AOwxWo7VBQKT1lOdwdvorddo2B/lk64+w==}
+  '@csstools/css-syntax-patches-for-csstree@1.1.3':
+    resolution: {integrity: sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==}
     peerDependencies:
       css-tree: ^3.2.1
     peerDependenciesMeta:
@@ -2524,6 +2540,11 @@ packages:
   '@tailwindcss/postcss@4.1.18':
     resolution: {integrity: sha512-Ce0GFnzAOuPyfV5SxjXGn0CubwGcuDB0zcdaPuCSzAa/2vII24JTkH+I6jcbXLb1ctjZMZZI6OjDaLPJQL1S0g==}
 
+  '@tailwindcss/typography@0.5.19':
+    resolution: {integrity: sha512-w31dd8HOx3k9vPtcQh5QHP9GwKcgbMp87j58qi6xgiBnFFtKEAgCWnDw4qUT8aHwkCp8bKvb/KGKWWHedP0AAg==}
+    peerDependencies:
+      tailwindcss: '>=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1'
+
   '@tailwindcss/vite@4.1.18':
     resolution: {integrity: sha512-jVA+/UpKL1vRLg6Hkao5jldawNmRo7mQYrZtNHMIVpLfLhDml5nMRUo/8MwoX2vNXvnaXNNMedrMfMugAVX1nA==}
     peerDependencies:
@@ -2824,6 +2845,9 @@ packages:
 
   '@types/sinonjs__fake-timers@8.1.5':
     resolution: {integrity: sha512-mQkU2jY8jJEF7YHjHvsQO8+3ughTL1mcnn96igfhONmR+fUPSKIkefQYpSe8bsly2Ep7oQbn/6VG5/9/0qcArQ==}
+
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
@@ -3819,6 +3843,9 @@ packages:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
 
+  dompurify@3.4.1:
+    resolution: {integrity: sha512-JahakDAIg1gyOm7dlgWSDjV4n7Ip2PKR55NIT6jrMfIgLFgWo81vdr1/QGqWtFNRqXP9UV71oVePtjqS2ebnPw==}
+
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
 
@@ -4026,6 +4053,10 @@ packages:
   entities@7.0.1:
     resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
     engines: {node: '>=0.12'}
+
+  entities@8.0.0:
+    resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
+    engines: {node: '>=20.19.0'}
 
   error-stack-parser-es@1.0.5:
     resolution: {integrity: sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==}
@@ -4633,6 +4664,10 @@ packages:
     resolution: {integrity: sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==}
     engines: {node: '>=20'}
 
+  isomorphic-dompurify@3.10.0:
+    resolution: {integrity: sha512-Gj2duy4dACsP/FLPvwJ3+MXTlGtOo+O4yfpA0jdxuz/sZlbZzazGzScajOHRwH7PCy4j3bh5ibLGJY4/Rb5kGQ==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24.0.0}
+
   isomorphic.js@0.2.5:
     resolution: {integrity: sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==}
 
@@ -4672,8 +4707,8 @@ packages:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
 
-  jsdom@29.0.1:
-    resolution: {integrity: sha512-z6JOK5gRO7aMybVq/y/MlIpKh8JIi68FBKMUtKkK2KH/wMSRlCxQ682d08LB9fYXplyY/UXG8P4XXTScmdjApg==}
+  jsdom@29.1.0:
+    resolution: {integrity: sha512-YNUc7fB9QuvSSQWfrH0xF+TyABkxUwx8sswgIDaCrw4Hol8BghdZDkITtZheRJeMtzWlnTfsM3bBBusRvpO1wg==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24.0.0}
     peerDependencies:
       canvas: ^3.0.0
@@ -5012,6 +5047,10 @@ packages:
     resolution: {integrity: sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==}
     engines: {node: 20 || >=22}
 
+  lru-cache@11.3.5:
+    resolution: {integrity: sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==}
+    engines: {node: 20 || >=22}
+
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
@@ -5036,8 +5075,8 @@ packages:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
 
-  markdown-it@14.1.0:
-    resolution: {integrity: sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==}
+  markdown-it@14.1.1:
+    resolution: {integrity: sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==}
     hasBin: true
 
   marked@15.0.12:
@@ -5437,8 +5476,8 @@ packages:
   parse5@7.3.0:
     resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
 
-  parse5@8.0.0:
-    resolution: {integrity: sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==}
+  parse5@8.0.1:
+    resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
 
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
@@ -5679,6 +5718,10 @@ packages:
     engines: {node: ^18.12.0 || ^20.9.0 || >=22.0}
     peerDependencies:
       postcss: ^8.4.32
+
+  postcss-selector-parser@6.0.10:
+    resolution: {integrity: sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==}
+    engines: {node: '>=4'}
 
   postcss-selector-parser@7.1.1:
     resolution: {integrity: sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==}
@@ -6450,8 +6493,8 @@ packages:
     resolution: {integrity: sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==}
     engines: {node: '>=20.18.1'}
 
-  undici@7.24.5:
-    resolution: {integrity: sha512-3IWdCpjgxp15CbJnsi/Y9TCDE7HWVN19j1hmzVhoAkY/+CJx449tVxT5wZc1Gwg8J+P0LWvzlBzxYRnHJ+1i7Q==}
+  undici@7.25.0:
+    resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
     engines: {node: '>=20.18.1'}
 
   unenv@2.0.0-rc.24:
@@ -7074,26 +7117,25 @@ snapshots:
       lru-cache: 10.4.3
       set-blocking: 2.0.0
 
-  '@asamuzakjp/css-color@5.0.1':
+  '@asamuzakjp/css-color@5.1.11':
     dependencies:
-      '@csstools/css-calc': 3.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
-      '@csstools/css-color-parser': 4.0.2(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@asamuzakjp/generational-cache': 1.0.1
+      '@csstools/css-calc': 3.2.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.1.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-tokenizer': 4.0.0
-      lru-cache: 11.2.7
-    optional: true
 
-  '@asamuzakjp/dom-selector@7.0.3':
+  '@asamuzakjp/dom-selector@7.1.1':
     dependencies:
+      '@asamuzakjp/generational-cache': 1.0.1
       '@asamuzakjp/nwsapi': 2.3.9
       bidi-js: 1.0.3
       css-tree: 3.2.1
       is-potential-custom-element-name: 1.0.1
-      lru-cache: 11.2.7
-    optional: true
 
-  '@asamuzakjp/nwsapi@2.3.9':
-    optional: true
+  '@asamuzakjp/generational-cache@1.0.1': {}
+
+  '@asamuzakjp/nwsapi@2.3.9': {}
 
   '@babel/code-frame@7.28.6':
     dependencies:
@@ -7273,7 +7315,6 @@ snapshots:
   '@bramus/specificity@2.4.2':
     dependencies:
       css-tree: 3.2.1
-    optional: true
 
   '@capsizecss/unpack@3.0.1':
     dependencies:
@@ -7292,35 +7333,29 @@ snapshots:
 
   '@cloudflare/kv-asset-handler@0.4.2': {}
 
-  '@csstools/color-helpers@6.0.2':
-    optional: true
+  '@csstools/color-helpers@6.0.2': {}
 
-  '@csstools/css-calc@3.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+  '@csstools/css-calc@3.2.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
     dependencies:
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-tokenizer': 4.0.0
-    optional: true
 
-  '@csstools/css-color-parser@4.0.2(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+  '@csstools/css-color-parser@4.1.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
     dependencies:
       '@csstools/color-helpers': 6.0.2
-      '@csstools/css-calc': 3.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-calc': 3.2.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-tokenizer': 4.0.0
-    optional: true
 
   '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
     dependencies:
       '@csstools/css-tokenizer': 4.0.0
-    optional: true
 
-  '@csstools/css-syntax-patches-for-csstree@1.1.1(css-tree@3.2.1)':
+  '@csstools/css-syntax-patches-for-csstree@1.1.3(css-tree@3.2.1)':
     optionalDependencies:
       css-tree: 3.2.1
-    optional: true
 
-  '@csstools/css-tokenizer@4.0.0':
-    optional: true
+  '@csstools/css-tokenizer@4.0.0': {}
 
   '@drizzle-team/brocli@0.10.2': {}
 
@@ -7614,8 +7649,7 @@ snapshots:
       '@eslint/core': 1.1.1
       levn: 0.4.1
 
-  '@exodus/bytes@1.15.0':
-    optional: true
+  '@exodus/bytes@1.15.0': {}
 
   '@floating-ui/core@1.7.3':
     dependencies:
@@ -9387,6 +9421,11 @@ snapshots:
       postcss: 8.5.6
       tailwindcss: 4.1.18
 
+  '@tailwindcss/typography@0.5.19(tailwindcss@4.1.18)':
+    dependencies:
+      postcss-selector-parser: 6.0.10
+      tailwindcss: 4.1.18
+
   '@tailwindcss/vite@4.1.18(vite@7.3.1(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(yaml@2.8.2))':
     dependencies:
       '@tailwindcss/node': 4.1.18
@@ -9701,6 +9740,9 @@ snapshots:
 
   '@types/sinonjs__fake-timers@8.1.5': {}
 
+  '@types/trusted-types@2.0.7':
+    optional: true
+
   '@types/unist@3.0.3': {}
 
   '@types/web-bluetooth@0.0.20': {}
@@ -9854,7 +9896,7 @@ snapshots:
       vite: 7.3.1(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(yaml@2.8.2)
       vue: 3.5.27(typescript@5.9.3)
 
-  '@vitest/coverage-v8@4.0.18(vitest@4.0.18(@types/node@25.4.0)(jiti@2.6.1)(jsdom@29.0.1)(lightningcss@1.31.1)(terser@5.46.0)(yaml@2.8.2))':
+  '@vitest/coverage-v8@4.0.18(vitest@4.0.18(@types/node@25.4.0)(jiti@2.6.1)(jsdom@29.1.0)(lightningcss@1.31.1)(terser@5.46.0)(yaml@2.8.2))':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
       '@vitest/utils': 4.0.18
@@ -9866,7 +9908,7 @@ snapshots:
       obug: 2.1.1
       std-env: 3.10.0
       tinyrainbow: 3.0.3
-      vitest: 4.0.18(@types/node@25.4.0)(jiti@2.6.1)(jsdom@29.0.1)(lightningcss@1.31.1)(terser@5.46.0)(yaml@2.8.2)
+      vitest: 4.0.18(@types/node@25.4.0)(jiti@2.6.1)(jsdom@29.1.0)(lightningcss@1.31.1)(terser@5.46.0)(yaml@2.8.2)
 
   '@vitest/expect@4.0.18':
     dependencies:
@@ -10386,7 +10428,6 @@ snapshots:
   bidi-js@1.0.3:
     dependencies:
       require-from-string: 2.0.2
-    optional: true
 
   bin-links@6.0.0:
     dependencies:
@@ -10673,7 +10714,6 @@ snapshots:
     dependencies:
       mdn-data: 2.27.1
       source-map-js: 1.2.1
-    optional: true
 
   css-value@0.0.1: {}
 
@@ -10750,7 +10790,6 @@ snapshots:
       whatwg-url: 16.0.1
     transitivePeerDependencies:
       - '@noble/hashes'
-    optional: true
 
   db0@0.3.4(drizzle-orm@0.45.1(postgres@3.4.8)):
     optionalDependencies:
@@ -10762,8 +10801,7 @@ snapshots:
 
   decamelize@6.0.1: {}
 
-  decimal.js@10.6.0:
-    optional: true
+  decimal.js@10.6.0: {}
 
   deep-is@0.1.4: {}
 
@@ -10821,6 +10859,10 @@ snapshots:
   domhandler@5.0.3:
     dependencies:
       domelementtype: 2.3.0
+
+  dompurify@3.4.1:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
 
   domutils@3.2.2:
     dependencies:
@@ -10937,6 +10979,8 @@ snapshots:
   entities@6.0.1: {}
 
   entities@7.0.1: {}
+
+  entities@8.0.0: {}
 
   error-stack-parser-es@1.0.5: {}
 
@@ -11502,7 +11546,6 @@ snapshots:
       '@exodus/bytes': 1.15.0
     transitivePeerDependencies:
       - '@noble/hashes'
-    optional: true
 
   html-escaper@2.0.2: {}
 
@@ -11643,8 +11686,7 @@ snapshots:
 
   is-plain-object@5.0.0: {}
 
-  is-potential-custom-element-name@1.0.1:
-    optional: true
+  is-potential-custom-element-name@1.0.1: {}
 
   is-reference@1.2.1:
     dependencies:
@@ -11679,6 +11721,14 @@ snapshots:
   isexe@3.1.1: {}
 
   isexe@4.0.0: {}
+
+  isomorphic-dompurify@3.10.0:
+    dependencies:
+      dompurify: 3.4.1
+      jsdom: 29.1.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
+      - canvas
 
   isomorphic.js@0.2.5: {}
 
@@ -11715,24 +11765,24 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
-  jsdom@29.0.1:
+  jsdom@29.1.0:
     dependencies:
-      '@asamuzakjp/css-color': 5.0.1
-      '@asamuzakjp/dom-selector': 7.0.3
+      '@asamuzakjp/css-color': 5.1.11
+      '@asamuzakjp/dom-selector': 7.1.1
       '@bramus/specificity': 2.4.2
-      '@csstools/css-syntax-patches-for-csstree': 1.1.1(css-tree@3.2.1)
+      '@csstools/css-syntax-patches-for-csstree': 1.1.3(css-tree@3.2.1)
       '@exodus/bytes': 1.15.0
       css-tree: 3.2.1
       data-urls: 7.0.0
       decimal.js: 10.6.0
       html-encoding-sniffer: 6.0.0
       is-potential-custom-element-name: 1.0.1
-      lru-cache: 11.2.7
-      parse5: 8.0.0
+      lru-cache: 11.3.5
+      parse5: 8.0.1
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.1
-      undici: 7.24.5
+      undici: 7.25.0
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -11740,7 +11790,6 @@ snapshots:
       xml-name-validator: 5.0.0
     transitivePeerDependencies:
       - '@noble/hashes'
-    optional: true
 
   jsesc@3.1.0: {}
 
@@ -12016,6 +12065,8 @@ snapshots:
 
   lru-cache@11.2.7: {}
 
+  lru-cache@11.3.5: {}
+
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
@@ -12050,7 +12101,7 @@ snapshots:
     dependencies:
       semver: 7.7.3
 
-  markdown-it@14.1.0:
+  markdown-it@14.1.1:
     dependencies:
       argparse: 2.0.1
       entities: 4.5.0
@@ -12077,8 +12128,7 @@ snapshots:
 
   mdn-data@2.12.2: {}
 
-  mdn-data@2.27.1:
-    optional: true
+  mdn-data@2.27.1: {}
 
   mdurl@2.0.0: {}
 
@@ -12775,10 +12825,9 @@ snapshots:
     dependencies:
       entities: 6.0.1
 
-  parse5@8.0.0:
+  parse5@8.0.1:
     dependencies:
-      entities: 6.0.1
-    optional: true
+      entities: 8.0.0
 
   parseurl@1.3.3: {}
 
@@ -12980,6 +13029,11 @@ snapshots:
       postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
+  postcss-selector-parser@6.0.10:
+    dependencies:
+      cssesc: 3.0.0
+      util-deprecate: 1.0.2
+
   postcss-selector-parser@7.1.1:
     dependencies:
       cssesc: 3.0.0
@@ -13072,7 +13126,7 @@ snapshots:
   prosemirror-markdown@1.13.3:
     dependencies:
       '@types/markdown-it': 14.1.2
-      markdown-it: 14.1.0
+      markdown-it: 14.1.1
       prosemirror-model: 1.25.4
 
   prosemirror-menu@1.2.5:
@@ -13243,8 +13297,7 @@ snapshots:
 
   require-directory@2.1.1: {}
 
-  require-from-string@2.0.2:
-    optional: true
+  require-from-string@2.0.2: {}
 
   resolve-from@5.0.0: {}
 
@@ -13348,7 +13401,6 @@ snapshots:
   saxes@6.0.0:
     dependencies:
       xmlchars: 2.2.0
-    optional: true
 
   scule@1.3.0: {}
 
@@ -13591,8 +13643,7 @@ snapshots:
       picocolors: 1.1.1
       sax: 1.4.4
 
-  symbol-tree@3.2.4:
-    optional: true
+  symbol-tree@3.2.4: {}
 
   system-architecture@0.1.0: {}
 
@@ -13702,13 +13753,11 @@ snapshots:
 
   tinyrainbow@3.0.3: {}
 
-  tldts-core@7.0.26:
-    optional: true
+  tldts-core@7.0.26: {}
 
   tldts@7.0.26:
     dependencies:
       tldts-core: 7.0.26
-    optional: true
 
   to-regex-range@5.0.1:
     dependencies:
@@ -13723,14 +13772,12 @@ snapshots:
   tough-cookie@6.0.1:
     dependencies:
       tldts: 7.0.26
-    optional: true
 
   tr46@0.0.3: {}
 
   tr46@6.0.0:
     dependencies:
       punycode: 2.3.1
-    optional: true
 
   tree-kill@1.2.2: {}
 
@@ -13825,8 +13872,7 @@ snapshots:
 
   undici@7.22.0: {}
 
-  undici@7.24.5:
-    optional: true
+  undici@7.25.0: {}
 
   unenv@2.0.0-rc.24:
     dependencies:
@@ -14142,7 +14188,7 @@ snapshots:
       terser: 5.46.0
       yaml: 2.8.2
 
-  vitest@4.0.18(@types/node@25.4.0)(jiti@2.6.1)(jsdom@29.0.1)(lightningcss@1.31.1)(terser@5.46.0)(yaml@2.8.2):
+  vitest@4.0.18(@types/node@25.4.0)(jiti@2.6.1)(jsdom@29.1.0)(lightningcss@1.31.1)(terser@5.46.0)(yaml@2.8.2):
     dependencies:
       '@vitest/expect': 4.0.18
       '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(yaml@2.8.2))
@@ -14166,7 +14212,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.4.0
-      jsdom: 29.0.1
+      jsdom: 29.1.0
     transitivePeerDependencies:
       - jiti
       - less
@@ -14251,7 +14297,6 @@ snapshots:
   w3c-xmlserializer@5.0.0:
     dependencies:
       xml-name-validator: 5.0.0
-    optional: true
 
   wait-port@1.1.0:
     dependencies:
@@ -14323,8 +14368,7 @@ snapshots:
 
   webidl-conversions@3.0.1: {}
 
-  webidl-conversions@8.0.1:
-    optional: true
+  webidl-conversions@8.0.1: {}
 
   webpack-virtual-modules@0.6.2: {}
 
@@ -14334,8 +14378,7 @@ snapshots:
 
   whatwg-mimetype@4.0.0: {}
 
-  whatwg-mimetype@5.0.0:
-    optional: true
+  whatwg-mimetype@5.0.0: {}
 
   whatwg-url@16.0.1:
     dependencies:
@@ -14344,7 +14387,6 @@ snapshots:
       webidl-conversions: 8.0.1
     transitivePeerDependencies:
       - '@noble/hashes'
-    optional: true
 
   whatwg-url@5.0.0:
     dependencies:
@@ -14397,11 +14439,9 @@ snapshots:
     dependencies:
       is-wsl: 3.1.0
 
-  xml-name-validator@5.0.0:
-    optional: true
+  xml-name-validator@5.0.0: {}
 
-  xmlchars@2.2.0:
-    optional: true
+  xmlchars@2.2.0: {}
 
   y-protocols@1.0.7(yjs@13.6.29):
     dependencies:


### PR DESCRIPTION
## Summary

- Add a new `curl-ticket-create-task` CLI skill with an interactive task creation flow, description templates, and bundled installation alongside the existing `curl-ticket` skill.
- Render issue descriptions as markdown on the issue detail page via a shared `MarkdownRenderer` component and `renderMarkdown` util, using `@tailwindcss/typography` for styling.
- Refactor `init-skill` to support installing multiple skills, cache template/skill source reads, and split `create-issue` into interactive/validators modules with new unit tests.

## Type of Change

- [x] feat: new feature
- [ ] fix: bug fix
- [ ] refactor: code restructuring (no behavior change)
- [ ] chore: maintenance, CI, deps
- [ ] docs: documentation only

## Related Issues

## Test Plan

- [x] Tested locally
- [x] Lint passes (`pnpm lint`)
- [x] Typecheck passes (`pnpm typecheck`)