### PR TITLE
chore(db): add FK constraints from data tables to profiles

### DIFF
--- a/scripts/check-orphans.mjs
+++ b/scripts/check-orphans.mjs
@@ -1,11 +1,8 @@
 /**
- * 孤兒資料檢查腳本（read-only）
+ * Read-only orphan check for FK candidate columns referencing profiles.id.
+ * Helps decide RESTRICT / SET NULL / CASCADE and whether to clean up before adding FKs.
  *
- * 在 PR 2「補 Foreign Key 約束」之前，列出每一個目標欄位中
- * 找不到對應 profiles.id 的資料列，幫助決定每個 FK 該用
- * RESTRICT / SET NULL / CASCADE，以及是否需要先清理資料。
- *
- * 用法：
+ * Usage:
  *   node scripts/check-orphans.mjs
  */
 import postgres from 'postgres'
@@ -18,16 +15,12 @@ if (DATABASE_URL) {
 }
 
 if (!DATABASE_URL) {
-  console.error('❌ 找不到 DATABASE_URL，請確認 .env')
+  console.error('❌ DATABASE_URL not found in .env')
   process.exit(1)
 }
 
 const sql = postgres(DATABASE_URL)
 
-/**
- * 待檢查的欄位清單。
- * - nullable=true 表示該欄位本身允許 NULL（NULL 不算孤兒）
- */
 const checks = [
   { table: 'projects', column: 'owner_id', nullable: false },
   { table: 'issues', column: 'created_by', nullable: false },
@@ -40,72 +33,73 @@ const checks = [
 ]
 
 try {
-  console.log('🔍 檢查孤兒資料（指向不存在的 profiles.id）...\n')
+  console.log('🔍 Checking orphans (rows pointing to a missing profiles.id)...\n')
 
-  const summary = []
-
-  for (const { table, column, nullable } of checks) {
-    // 找出非 NULL 但找不到對應 profile 的列
-    const orphans = await sql`
-      SELECT ${sql(column)} AS missing_id, COUNT(*) AS count
-      FROM ${sql(table)}
-      WHERE ${sql(column)} IS NOT NULL
-        AND NOT EXISTS (
-          SELECT 1 FROM profiles p WHERE p.id = ${sql(table)}.${sql(column)}
+  // One round-trip per column, all 8 in parallel.
+  const results = await Promise.all(
+    checks.map(async ({ table, column, nullable }) => {
+      const [{ table_total, orphan_total, top_missing }] = await sql`
+        WITH orphans AS (
+          SELECT ${sql(column)} AS missing_id
+          FROM ${sql(table)}
+          WHERE ${sql(column)} IS NOT NULL
+            AND NOT EXISTS (
+              SELECT 1 FROM profiles p
+              WHERE p.id = ${sql(table)}.${sql(column)}
+            )
         )
-      GROUP BY ${sql(column)}
-      ORDER BY count DESC
-      LIMIT 20
-    `
+        SELECT
+          (SELECT COUNT(*)::int FROM ${sql(table)}) AS table_total,
+          (SELECT COUNT(*)::int FROM orphans) AS orphan_total,
+          COALESCE(
+            (SELECT json_agg(row_to_json(t)) FROM (
+              SELECT missing_id, COUNT(*)::int AS count
+              FROM orphans
+              GROUP BY missing_id
+              ORDER BY count DESC
+              LIMIT 20
+            ) t),
+            '[]'::json
+          ) AS top_missing
+      `
+      return { table, column, nullable, table_total, orphan_total, top_missing }
+    })
+  )
 
-    const totalQuery = await sql`
-      SELECT COUNT(*) AS count
-      FROM ${sql(table)}
-      WHERE ${sql(column)} IS NOT NULL
-        AND NOT EXISTS (
-          SELECT 1 FROM profiles p WHERE p.id = ${sql(table)}.${sql(column)}
-        )
-    `
-    const totalOrphans = Number(totalQuery[0].count)
-
-    const tableTotalQuery = await sql`SELECT COUNT(*) AS count FROM ${sql(table)}`
-    const tableTotal = Number(tableTotalQuery[0].count)
-
-    const status = totalOrphans === 0 ? '✅' : '⚠️'
-    console.log(`${status} ${table}.${column} ${nullable ? '(nullable)' : '(not null)'}`)
-    console.log(`   total rows: ${tableTotal}, orphan rows: ${totalOrphans}`)
-    if (totalOrphans > 0) {
-      console.log(`   top missing IDs (up to 20):`)
-      for (const row of orphans) {
+  for (const r of results) {
+    const status = r.orphan_total === 0 ? '✅' : '⚠️'
+    console.log(`${status} ${r.table}.${r.column} ${r.nullable ? '(nullable)' : '(not null)'}`)
+    console.log(`   total rows: ${r.table_total}, orphan rows: ${r.orphan_total}`)
+    if (r.orphan_total > 0) {
+      console.log('   top missing IDs (up to 20):')
+      for (const row of r.top_missing) {
         console.log(`     ${row.missing_id}  → ${row.count} row(s)`)
       }
     }
     console.log()
-
-    summary.push({ table, column, nullable, totalOrphans, tableTotal })
   }
 
   console.log('───────────────────────────────────')
   console.log('Summary:')
   console.log('───────────────────────────────────')
-  for (const s of summary) {
-    const flag = s.totalOrphans === 0 ? 'OK' : 'NEEDS ACTION'
+  for (const r of results) {
+    const flag = r.orphan_total === 0 ? 'OK' : 'NEEDS ACTION'
     console.log(
-      `  [${flag}] ${s.table}.${s.column}  orphans=${s.totalOrphans} / total=${s.tableTotal}`
+      `  [${flag}] ${r.table}.${r.column}  orphans=${r.orphan_total} / total=${r.table_total}`
     )
   }
 
-  const anyOrphan = summary.some((s) => s.totalOrphans > 0)
+  const anyOrphan = results.some((r) => r.orphan_total > 0)
   if (anyOrphan) {
-    console.log('\n⚠️  發現孤兒資料。請決定每個欄位是否：')
-    console.log('   1. 刪除孤兒列')
-    console.log('   2. 補上對應 profile')
-    console.log('   3. 把欄位改成 nullable + ON DELETE SET NULL')
+    console.log('\n⚠️  Orphans found. For each affected column, decide:')
+    console.log('   1. delete the orphan rows')
+    console.log('   2. backfill the missing profiles')
+    console.log('   3. set the column nullable + ON DELETE SET NULL')
   } else {
-    console.log('\n✅ 沒有孤兒資料，可以安全加 FK 約束')
+    console.log('\n✅ No orphans — safe to add FK constraints')
   }
 } catch (error) {
-  console.error('❌ 錯誤:', error)
+  console.error('❌ Error:', error)
   process.exit(1)
 } finally {
   await sql.end()

--- a/scripts/check-orphans.mjs
+++ b/scripts/check-orphans.mjs
@@ -1,0 +1,112 @@
+/**
+ * 孤兒資料檢查腳本（read-only）
+ *
+ * 在 PR 2「補 Foreign Key 約束」之前，列出每一個目標欄位中
+ * 找不到對應 profiles.id 的資料列，幫助決定每個 FK 該用
+ * RESTRICT / SET NULL / CASCADE，以及是否需要先清理資料。
+ *
+ * 用法：
+ *   node scripts/check-orphans.mjs
+ */
+import postgres from 'postgres'
+import { readFileSync } from 'fs'
+
+const env = readFileSync('.env', 'utf-8')
+let DATABASE_URL = env.match(/DATABASE_URL=(.+)/)?.[1]?.trim()
+if (DATABASE_URL) {
+  DATABASE_URL = DATABASE_URL.replace(/^["']|["']$/g, '')
+}
+
+if (!DATABASE_URL) {
+  console.error('❌ 找不到 DATABASE_URL，請確認 .env')
+  process.exit(1)
+}
+
+const sql = postgres(DATABASE_URL)
+
+/**
+ * 待檢查的欄位清單。
+ * - nullable=true 表示該欄位本身允許 NULL（NULL 不算孤兒）
+ */
+const checks = [
+  { table: 'projects', column: 'owner_id', nullable: false },
+  { table: 'issues', column: 'created_by', nullable: false },
+  { table: 'issue_comments', column: 'author_id', nullable: false },
+  { table: 'notifications', column: 'user_id', nullable: false },
+  { table: 'project_invitations', column: 'invited_by', nullable: false },
+  { table: 'invitation_codes', column: 'created_by', nullable: false },
+  { table: 'invitation_codes', column: 'used_by', nullable: true },
+  { table: 'device_codes', column: 'user_id', nullable: true }
+]
+
+try {
+  console.log('🔍 檢查孤兒資料（指向不存在的 profiles.id）...\n')
+
+  const summary = []
+
+  for (const { table, column, nullable } of checks) {
+    // 找出非 NULL 但找不到對應 profile 的列
+    const orphans = await sql`
+      SELECT ${sql(column)} AS missing_id, COUNT(*) AS count
+      FROM ${sql(table)}
+      WHERE ${sql(column)} IS NOT NULL
+        AND NOT EXISTS (
+          SELECT 1 FROM profiles p WHERE p.id = ${sql(table)}.${sql(column)}
+        )
+      GROUP BY ${sql(column)}
+      ORDER BY count DESC
+      LIMIT 20
+    `
+
+    const totalQuery = await sql`
+      SELECT COUNT(*) AS count
+      FROM ${sql(table)}
+      WHERE ${sql(column)} IS NOT NULL
+        AND NOT EXISTS (
+          SELECT 1 FROM profiles p WHERE p.id = ${sql(table)}.${sql(column)}
+        )
+    `
+    const totalOrphans = Number(totalQuery[0].count)
+
+    const tableTotalQuery = await sql`SELECT COUNT(*) AS count FROM ${sql(table)}`
+    const tableTotal = Number(tableTotalQuery[0].count)
+
+    const status = totalOrphans === 0 ? '✅' : '⚠️'
+    console.log(`${status} ${table}.${column} ${nullable ? '(nullable)' : '(not null)'}`)
+    console.log(`   total rows: ${tableTotal}, orphan rows: ${totalOrphans}`)
+    if (totalOrphans > 0) {
+      console.log(`   top missing IDs (up to 20):`)
+      for (const row of orphans) {
+        console.log(`     ${row.missing_id}  → ${row.count} row(s)`)
+      }
+    }
+    console.log()
+
+    summary.push({ table, column, nullable, totalOrphans, tableTotal })
+  }
+
+  console.log('───────────────────────────────────')
+  console.log('Summary:')
+  console.log('───────────────────────────────────')
+  for (const s of summary) {
+    const flag = s.totalOrphans === 0 ? 'OK' : 'NEEDS ACTION'
+    console.log(
+      `  [${flag}] ${s.table}.${s.column}  orphans=${s.totalOrphans} / total=${s.tableTotal}`
+    )
+  }
+
+  const anyOrphan = summary.some((s) => s.totalOrphans > 0)
+  if (anyOrphan) {
+    console.log('\n⚠️  發現孤兒資料。請決定每個欄位是否：')
+    console.log('   1. 刪除孤兒列')
+    console.log('   2. 補上對應 profile')
+    console.log('   3. 把欄位改成 nullable + ON DELETE SET NULL')
+  } else {
+    console.log('\n✅ 沒有孤兒資料，可以安全加 FK 約束')
+  }
+} catch (error) {
+  console.error('❌ 錯誤:', error)
+  process.exit(1)
+} finally {
+  await sql.end()
+}

--- a/server/api/invitation-codes/redeem.post.ts
+++ b/server/api/invitation-codes/redeem.post.ts
@@ -21,10 +21,13 @@ export default defineEventHandler(async (event) => {
   }
 
   const code = await validateInvitationToken(db, result.data.code)
-  await markInvitationTokenAsUsed(db, code.id, userId)
 
-  // 兌換成功後建立 profile
-  await getOrCreateProfile(db, userId, userEmail, userMetadata?.full_name)
+  // 必須先建 profile 再標記 used_by，否則 invitation_codes.used_by → profiles.id
+  // FK 約束會失敗。包進 transaction 確保兩步皆成功或一起 rollback。
+  await db.transaction(async (tx) => {
+    await getOrCreateProfile(tx, userId, userEmail, userMetadata?.full_name)
+    await markInvitationTokenAsUsed(tx, code.id, userId)
+  })
 
   return { success: true }
 })

--- a/server/database/migrations/0023_wealthy_brother_voodoo.sql
+++ b/server/database/migrations/0023_wealthy_brother_voodoo.sql
@@ -1,5 +1,6 @@
--- 清理孤兒資料：將 invitation_codes.used_by 中指向不存在 profile 的值設為 NULL，
--- 否則下方 invitation_codes_used_by_profiles_id_fk 約束會建立失敗。
+-- ⚠️  Manually edited: do NOT re-run `pnpm db:generate` against this migration —
+-- the cleanup UPDATE below is not produced by Drizzle and will be lost.
+-- Cleans up orphan rows so the FK on invitation_codes.used_by can be created.
 UPDATE "invitation_codes"
 SET "used_by" = NULL
 WHERE "used_by" IS NOT NULL

--- a/server/database/migrations/0023_wealthy_brother_voodoo.sql
+++ b/server/database/migrations/0023_wealthy_brother_voodoo.sql
@@ -1,0 +1,16 @@
+-- 清理孤兒資料：將 invitation_codes.used_by 中指向不存在 profile 的值設為 NULL，
+-- 否則下方 invitation_codes_used_by_profiles_id_fk 約束會建立失敗。
+UPDATE "invitation_codes"
+SET "used_by" = NULL
+WHERE "used_by" IS NOT NULL
+  AND NOT EXISTS (SELECT 1 FROM "profiles" p WHERE p."id" = "invitation_codes"."used_by");--> statement-breakpoint
+ALTER TABLE "projects" ADD CONSTRAINT "projects_owner_id_profiles_id_fk" FOREIGN KEY ("owner_id") REFERENCES "public"."profiles"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "issues" ADD CONSTRAINT "issues_created_by_profiles_id_fk" FOREIGN KEY ("created_by") REFERENCES "public"."profiles"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "notifications" ADD CONSTRAINT "notifications_user_id_profiles_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."profiles"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "invitation_codes" ADD CONSTRAINT "invitation_codes_created_by_profiles_id_fk" FOREIGN KEY ("created_by") REFERENCES "public"."profiles"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "invitation_codes" ADD CONSTRAINT "invitation_codes_used_by_profiles_id_fk" FOREIGN KEY ("used_by") REFERENCES "public"."profiles"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "project_invitations" ADD CONSTRAINT "project_invitations_invited_by_profiles_id_fk" FOREIGN KEY ("invited_by") REFERENCES "public"."profiles"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "issue_comments" ADD CONSTRAINT "issue_comments_author_id_profiles_id_fk" FOREIGN KEY ("author_id") REFERENCES "public"."profiles"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "device_codes" ADD CONSTRAINT "device_codes_user_id_profiles_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."profiles"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "invitation_codes_used_by_idx" ON "invitation_codes" USING btree ("used_by") WHERE "invitation_codes"."used_by" is not null;--> statement-breakpoint
+CREATE INDEX "device_codes_user_id_idx" ON "device_codes" USING btree ("user_id") WHERE "device_codes"."user_id" is not null;

--- a/server/database/migrations/meta/0023_snapshot.json
+++ b/server/database/migrations/meta/0023_snapshot.json
@@ -1,0 +1,1298 @@
+{
+  "id": "554428ed-727d-4e73-8fff-43c2031490f5",
+  "prevId": "22c7c0c4-a9f0-4086-bfa0-3a2a90bd4924",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "environments": {
+          "name": "environments",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "projects_key_active_idx": {
+          "name": "projects_key_active_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"projects\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "projects_created_at_idx": {
+          "name": "projects_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "projects_owner_id_active_idx": {
+          "name": "projects_owner_id_active_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"projects\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "projects_owner_id_profiles_id_fk": {
+          "name": "projects_owner_id_profiles_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issues": {
+      "name": "issues",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_number": {
+          "name": "issue_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_key": {
+          "name": "project_key",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_type": {
+          "name": "issue_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'api_bug'"
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_curl": {
+          "name": "raw_curl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "method": {
+          "name": "method",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "environment": {
+          "name": "environment",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'Dev'"
+        },
+        "request_headers": {
+          "name": "request_headers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_body": {
+          "name": "request_body",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_status": {
+          "name": "response_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_body": {
+          "name": "response_body",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Open'"
+        },
+        "assignee_id": {
+          "name": "assignee_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "issues_project_stats_idx": {
+          "name": "issues_project_stats_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issues_project_issue_number_key": {
+          "name": "issues_project_issue_number_key",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "issue_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issues_project_list_idx": {
+          "name": "issues_project_list_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "issue_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issues_assignee_idx": {
+          "name": "issues_assignee_idx",
+          "columns": [
+            {
+              "expression": "assignee_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issues_project_id_projects_id_fk": {
+          "name": "issues_project_id_projects_id_fk",
+          "tableFrom": "issues",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issues_assignee_id_profiles_id_fk": {
+          "name": "issues_assignee_id_profiles_id_fk",
+          "tableFrom": "issues",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "assignee_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "issues_created_by_profiles_id_fk": {
+          "name": "issues_created_by_profiles_id_fk",
+          "tableFrom": "issues",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "issues_status_check": {
+          "name": "issues_status_check",
+          "value": "\"issues\".\"status\" in ('Open', 'In Progress', 'Done', 'Close')"
+        },
+        "issues_type_check": {
+          "name": "issues_type_check",
+          "value": "\"issues\".\"issue_type\" in ('api_bug', 'task')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'issue_update'"
+        },
+        "project_invitation_id": {
+          "name": "project_invitation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notifications_user_unread_idx": {
+          "name": "notifications_user_unread_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_read",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_user_id_profiles_id_fk": {
+          "name": "notifications_user_id_profiles_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notifications_issue_id_issues_id_fk": {
+          "name": "notifications_issue_id_issues_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notifications_project_invitation_id_project_invitations_id_fk": {
+          "name": "notifications_project_invitation_id_project_invitations_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "project_invitations",
+          "columnsFrom": [
+            "project_invitation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_members": {
+      "name": "project_members",
+      "schema": "",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_members_user_id_idx": {
+          "name": "project_members_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_members_project_id_projects_id_fk": {
+          "name": "project_members_project_id_projects_id_fk",
+          "tableFrom": "project_members",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "project_members_pkey": {
+          "name": "project_members_pkey",
+          "columns": [
+            "project_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profiles": {
+      "name": "profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "profiles_email_unique": {
+          "name": "profiles_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation_codes": {
+      "name": "invitation_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(6)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_by": {
+          "name": "used_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_used": {
+          "name": "is_used",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "invitation_codes_is_used_idx": {
+          "name": "invitation_codes_is_used_idx",
+          "columns": [
+            {
+              "expression": "is_used",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitation_codes_used_by_idx": {
+          "name": "invitation_codes_used_by_idx",
+          "columns": [
+            {
+              "expression": "used_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"invitation_codes\".\"used_by\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitation_codes_created_by_profiles_id_fk": {
+          "name": "invitation_codes_created_by_profiles_id_fk",
+          "tableFrom": "invitation_codes",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "invitation_codes_used_by_profiles_id_fk": {
+          "name": "invitation_codes_used_by_profiles_id_fk",
+          "tableFrom": "invitation_codes",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "used_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invitation_codes_code_unique": {
+          "name": "invitation_codes_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_invitations": {
+      "name": "project_invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "project_invitations_project_id_idx": {
+          "name": "project_invitations_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_invitations_email_idx": {
+          "name": "project_invitations_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_invitations_status_idx": {
+          "name": "project_invitations_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_invitations_project_id_projects_id_fk": {
+          "name": "project_invitations_project_id_projects_id_fk",
+          "tableFrom": "project_invitations",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_invitations_invited_by_profiles_id_fk": {
+          "name": "project_invitations_invited_by_profiles_id_fk",
+          "tableFrom": "project_invitations",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "invited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_comments": {
+      "name": "issue_comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "issue_comments_issue_id_idx": {
+          "name": "issue_comments_issue_id_idx",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_comments_issue_created_idx": {
+          "name": "issue_comments_issue_created_idx",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_comments_issue_id_issues_id_fk": {
+          "name": "issue_comments_issue_id_issues_id_fk",
+          "tableFrom": "issue_comments",
+          "tableTo": "issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_comments_author_id_profiles_id_fk": {
+          "name": "issue_comments_author_id_profiles_id_fk",
+          "tableFrom": "issue_comments",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_tokens": {
+      "name": "api_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "api_tokens_user_id_idx": {
+          "name": "api_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_tokens_token_hash_idx": {
+          "name": "api_tokens_token_hash_idx",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_tokens_user_id_profiles_id_fk": {
+          "name": "api_tokens_user_id_profiles_id_fk",
+          "tableFrom": "api_tokens",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.device_codes": {
+      "name": "device_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "device_code": {
+          "name": "device_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_code": {
+          "name": "user_code",
+          "type": "varchar(9)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_plaintext": {
+          "name": "token_plaintext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "device_codes_user_id_idx": {
+          "name": "device_codes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"device_codes\".\"user_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "device_codes_user_id_profiles_id_fk": {
+          "name": "device_codes_user_id_profiles_id_fk",
+          "tableFrom": "device_codes",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "device_codes_device_code_unique": {
+          "name": "device_codes_device_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "device_code"
+          ]
+        },
+        "device_codes_user_code_unique": {
+          "name": "device_codes_user_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/server/database/migrations/meta/_journal.json
+++ b/server/database/migrations/meta/_journal.json
@@ -162,6 +162,13 @@
       "when": 1777993683347,
       "tag": "0022_aromatic_meggan",
       "breakpoints": true
+    },
+    {
+      "idx": 23,
+      "version": "7",
+      "when": 1777995555964,
+      "tag": "0023_wealthy_brother_voodoo",
+      "breakpoints": true
     }
   ]
 }

--- a/server/database/schema/device-codes.ts
+++ b/server/database/schema/device-codes.ts
@@ -1,16 +1,27 @@
-import { pgTable, uuid, text, varchar, timestamp } from 'drizzle-orm/pg-core'
+import { sql } from 'drizzle-orm'
+import { pgTable, uuid, text, varchar, timestamp, index } from 'drizzle-orm/pg-core'
+import { profiles } from './profiles'
 
 /**
  * Device Codes 資料表
  * 用於 CLI Device Code Flow 登入
  */
-export const deviceCodes = pgTable('device_codes', {
-  id: uuid('id').primaryKey().defaultRandom(),
-  deviceCode: text('device_code').unique().notNull(),
-  userCode: varchar('user_code', { length: 9 }).unique().notNull(),
-  userId: uuid('user_id'),
-  tokenPlaintext: text('token_plaintext'), // 暫存明碼 token，CLI 取用一次後清除
-  status: varchar('status', { length: 20 }).default('pending').notNull(),
-  expiresAt: timestamp('expires_at', { withTimezone: true }).notNull(),
-  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull()
-})
+export const deviceCodes = pgTable(
+  'device_codes',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    deviceCode: text('device_code').unique().notNull(),
+    userCode: varchar('user_code', { length: 9 }).unique().notNull(),
+    userId: uuid('user_id').references(() => profiles.id, { onDelete: 'cascade' }),
+    tokenPlaintext: text('token_plaintext'), // 暫存明碼 token，CLI 取用一次後清除
+    status: varchar('status', { length: 20 }).default('pending').notNull(),
+    expiresAt: timestamp('expires_at', { withTimezone: true }).notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull()
+  },
+  (table) => [
+    // FK index：加速 user_id 的 CASCADE 查詢
+    index('device_codes_user_id_idx')
+      .on(table.userId)
+      .where(sql`${table.userId} is not null`)
+  ]
+)

--- a/server/database/schema/invitation-codes.ts
+++ b/server/database/schema/invitation-codes.ts
@@ -1,4 +1,6 @@
+import { sql } from 'drizzle-orm'
 import { pgTable, uuid, varchar, timestamp, boolean, index } from 'drizzle-orm/pg-core'
+import { profiles } from './profiles'
 
 /**
  * Invitation Codes 資料表
@@ -9,12 +11,20 @@ export const invitationCodes = pgTable(
   {
     id: uuid('id').primaryKey().defaultRandom(),
     code: varchar('code', { length: 6 }).notNull().unique(),
-    createdBy: uuid('created_by').notNull(),
-    usedBy: uuid('used_by'),
+    createdBy: uuid('created_by')
+      .notNull()
+      .references(() => profiles.id, { onDelete: 'restrict' }),
+    usedBy: uuid('used_by').references(() => profiles.id, { onDelete: 'set null' }),
     isUsed: boolean('is_used').notNull().default(false),
     expiresAt: timestamp('expires_at', { withTimezone: true }),
     createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
     usedAt: timestamp('used_at', { withTimezone: true })
   },
-  (table) => [index('invitation_codes_is_used_idx').on(table.isUsed)]
+  (table) => [
+    index('invitation_codes_is_used_idx').on(table.isUsed),
+    // FK index：加速 used_by 的 SET NULL cascade 查詢
+    index('invitation_codes_used_by_idx')
+      .on(table.usedBy)
+      .where(sql`${table.usedBy} is not null`)
+  ]
 )

--- a/server/database/schema/issue-comments.ts
+++ b/server/database/schema/issue-comments.ts
@@ -1,5 +1,6 @@
 import { pgTable, serial, integer, uuid, text, timestamp, index } from 'drizzle-orm/pg-core'
 import { issues } from './issues'
+import { profiles } from './profiles'
 
 export const issueComments = pgTable(
   'issue_comments',
@@ -8,7 +9,9 @@ export const issueComments = pgTable(
     issueId: integer('issue_id')
       .notNull()
       .references(() => issues.id, { onDelete: 'cascade' }),
-    authorId: uuid('author_id').notNull(),
+    authorId: uuid('author_id')
+      .notNull()
+      .references(() => profiles.id, { onDelete: 'restrict' }),
     content: text('content').notNull(),
     createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
     updatedAt: timestamp('updated_at', { withTimezone: true })

--- a/server/database/schema/issues.ts
+++ b/server/database/schema/issues.ts
@@ -60,7 +60,9 @@ export const issues = pgTable(
       .$type<IssueStatus>()
       .default(IssueStatus.Open),
     assigneeId: uuid('assignee_id').references(() => profiles.id, { onDelete: 'set null' }),
-    createdBy: uuid('created_by').notNull(),
+    createdBy: uuid('created_by')
+      .notNull()
+      .references(() => profiles.id, { onDelete: 'restrict' }),
     createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
     updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull()
   },

--- a/server/database/schema/notifications.ts
+++ b/server/database/schema/notifications.ts
@@ -1,5 +1,6 @@
 import { pgTable, uuid, varchar, timestamp, boolean, integer, index } from 'drizzle-orm/pg-core'
 import { issues } from './issues'
+import { profiles } from './profiles'
 import { projectInvitations } from './project-invitations'
 import type { NotificationType } from '~~/shared/constants'
 
@@ -7,7 +8,9 @@ export const notifications = pgTable(
   'notifications',
   {
     id: uuid('id').primaryKey().defaultRandom(),
-    userId: uuid('user_id').notNull(), // FK to auth.users (接收通知的人)
+    userId: uuid('user_id')
+      .notNull()
+      .references(() => profiles.id, { onDelete: 'cascade' }),
     issueId: integer('issue_id').references(() => issues.id, { onDelete: 'cascade' }),
 
     type: varchar('type', { length: 30 })

--- a/server/database/schema/project-invitations.ts
+++ b/server/database/schema/project-invitations.ts
@@ -1,4 +1,5 @@
 import { pgTable, uuid, varchar, timestamp, index } from 'drizzle-orm/pg-core'
+import { profiles } from './profiles'
 import { projects } from './projects'
 import { InvitationStatus } from '../../../shared/constants'
 
@@ -14,7 +15,9 @@ export const projectInvitations = pgTable(
       .notNull()
       .references(() => projects.id, { onDelete: 'cascade' }),
     email: varchar('email', { length: 255 }).notNull(),
-    invitedBy: uuid('invited_by').notNull(),
+    invitedBy: uuid('invited_by')
+      .notNull()
+      .references(() => profiles.id, { onDelete: 'restrict' }),
     status: varchar('status', { length: 20 })
       .notNull()
       .$type<InvitationStatus>()

--- a/server/database/schema/projects.ts
+++ b/server/database/schema/projects.ts
@@ -1,5 +1,6 @@
 import { sql } from 'drizzle-orm'
 import { pgTable, uuid, varchar, timestamp, text, index, uniqueIndex } from 'drizzle-orm/pg-core'
+import { profiles } from './profiles'
 
 /**
  * Projects 資料表
@@ -8,7 +9,9 @@ export const projects = pgTable(
   'projects',
   {
     id: uuid('id').primaryKey().defaultRandom(),
-    ownerId: uuid('owner_id').notNull(),
+    ownerId: uuid('owner_id')
+      .notNull()
+      .references(() => profiles.id, { onDelete: 'restrict' }),
     name: varchar('name', { length: 100 }).notNull(),
     key: varchar('key', { length: 10 }).notNull(),
     description: varchar('description', { length: 1000 }),

--- a/server/utils/db.ts
+++ b/server/utils/db.ts
@@ -14,4 +14,20 @@ export function useDB() {
   return _db
 }
 
+/**
+ * Drizzle DB client（一般查詢用）
+ */
+export type DbClient = ReturnType<typeof useDB>
+
+/**
+ * Drizzle transaction object（從 db.transaction 的 callback 取出的型別）
+ */
+export type DbTransaction = Parameters<Parameters<DbClient['transaction']>[0]>[0]
+
+/**
+ * 接受一般 db 或 transaction tx 的通用型別。
+ * 共用 helper 函式應使用此型別，便於同時被 transaction 內外呼叫。
+ */
+export type DbOrTx = DbClient | DbTransaction
+
 export * from '../database/schema'

--- a/server/utils/db.ts
+++ b/server/utils/db.ts
@@ -14,20 +14,10 @@ export function useDB() {
   return _db
 }
 
-/**
- * Drizzle DB client（一般查詢用）
- */
-export type DbClient = ReturnType<typeof useDB>
+type Db = ReturnType<typeof useDB>
+type Tx = Parameters<Parameters<Db['transaction']>[0]>[0]
 
-/**
- * Drizzle transaction object（從 db.transaction 的 callback 取出的型別）
- */
-export type DbTransaction = Parameters<Parameters<DbClient['transaction']>[0]>[0]
-
-/**
- * 接受一般 db 或 transaction tx 的通用型別。
- * 共用 helper 函式應使用此型別，便於同時被 transaction 內外呼叫。
- */
-export type DbOrTx = DbClient | DbTransaction
+/** Accepts either the singleton DB client or a transaction handle from `db.transaction`. */
+export type DbOrTx = Db | Tx
 
 export * from '../database/schema'

--- a/server/utils/invitation-code.ts
+++ b/server/utils/invitation-code.ts
@@ -15,7 +15,7 @@ export function generateInvitationToken(): string {
  * 驗證邀請 token 是否有效（未使用、未過期）
  * 無效則 throw BadRequest
  */
-export async function validateInvitationToken(db: ReturnType<typeof useDB>, token: string) {
+export async function validateInvitationToken(db: DbOrTx, token: string) {
   const [code] = await db
     .select()
     .from(invitationCodes)
@@ -36,11 +36,7 @@ export async function validateInvitationToken(db: ReturnType<typeof useDB>, toke
 /**
  * 標記邀請 token 為已使用
  */
-export async function markInvitationTokenAsUsed(
-  db: ReturnType<typeof useDB>,
-  tokenId: string,
-  userId: string
-) {
+export async function markInvitationTokenAsUsed(db: DbOrTx, tokenId: string, userId: string) {
   await db
     .update(invitationCodes)
     .set({

--- a/server/utils/profile.ts
+++ b/server/utils/profile.ts
@@ -7,7 +7,7 @@ import { forbidden } from '~~/server/utils/errors'
  * 檢查用戶是否為 Admin，不是就 throw 403
  * 優先使用 event.context.profile（middleware 已查詢），避免重複查 DB
  */
-export async function requireAdmin(db: ReturnType<typeof useDB>, userId: string, event?: H3Event) {
+export async function requireAdmin(db: DbOrTx, userId: string, event?: H3Event) {
   const profile = event?.context.profile ?? (await getProfile(db, userId))
 
   if (profile?.role !== 'admin') {
@@ -18,7 +18,7 @@ export async function requireAdmin(db: ReturnType<typeof useDB>, userId: string,
 /**
  * 查詢用戶 Profile（只查詢，不建立）
  */
-export async function getProfile(db: ReturnType<typeof useDB>, userId: string) {
+export async function getProfile(db: DbOrTx, userId: string) {
   const [profile] = await db
     .select()
     .from(profiles)
@@ -31,12 +31,7 @@ export async function getProfile(db: ReturnType<typeof useDB>, userId: string) {
 /**
  * 取得或建立用戶 Profile（僅在 redeem 邀請碼時使用）
  */
-export async function getOrCreateProfile(
-  db: ReturnType<typeof useDB>,
-  userId: string,
-  email: string,
-  name?: string
-) {
+export async function getOrCreateProfile(db: DbOrTx, userId: string, email: string, name?: string) {
   const [existing] = await db.select().from(profiles).where(eq(profiles.id, userId)).limit(1)
 
   if (existing) {
@@ -70,7 +65,7 @@ export async function getOrCreateProfile(
 /**
  * 依 Email 查找 Profile
  */
-export async function getProfileByEmail(db: ReturnType<typeof useDB>, email: string) {
+export async function getProfileByEmail(db: DbOrTx, email: string) {
   const [profile] = await db
     .select()
     .from(profiles)


### PR DESCRIPTION
## Summary

- Add 8 foreign keys from data tables to `profiles.id` with explicit ON DELETE policies (`RESTRICT` for ownership/authorship records, `CASCADE` for personal artifacts, `SET NULL` for historical references).
- Migration `0023` pre-cleans 3 orphan rows in `invitation_codes.used_by` before adding the FK, and adds two partial indexes for the CASCADE/SET NULL paths.
- Wraps the invite redemption flow in a transaction and reorders so `getOrCreateProfile` runs before `markInvitationTokenAsUsed` (the new FK requires the profile to exist first). Exposes a shared `DbOrTx` type so helpers work in both regular and transaction contexts.
- Adds `scripts/check-orphans.mjs`, a reusable read-only orphan probe used to vet this PR and future FK additions.

## Type of Change

- [ ] feat: new feature
- [x] fix: bug fix (invite redemption flow regression that the new FK would otherwise introduce)
- [ ] refactor: code restructuring (no behavior change)
- [x] chore: maintenance, CI, deps
- [ ] docs: documentation only

## Related Issues

Follow-up to #19. Stage 2 of the DB best-practices audit.

## Test Plan

- [x] Lint passes (`pnpm lint`)
- [x] Typecheck passes (`pnpm typecheck`)
- [x] All 265 unit tests pass (`pnpm test:run`)
- [x] `scripts/check-orphans.mjs` run against current DB — only `invitation_codes.used_by` has 3 orphans, all handled by the migration's pre-cleanup UPDATE
- [x] Codex review — caught the original ordering bug (P1), now fixed by the transaction wrap
- [ ] CI `migrate` job will apply `0023_wealthy_brother_voodoo.sql` on merge

### Notes for reviewer

- **ON DELETE choices:**
  - `RESTRICT`: `projects.owner_id`, `issues.created_by`, `issue_comments.author_id`, `project_invitations.invited_by`, `invitation_codes.created_by`
  - `CASCADE`: `notifications.user_id`, `device_codes.user_id`
  - `SET NULL`: `invitation_codes.used_by` (already nullable)
- **Migration file is hand-edited** at the top to add the orphan cleanup UPDATE. The file carries a "manually edited; do not regenerate" warning so future `pnpm db:generate` runs don't silently drop it.
- Why `getOrCreateProfile` was not collapsed into a single upsert: the existing branch logic restores soft-deleted profiles only conditionally; a blanket upsert would overwrite `email`/`name` on every redeem.
- FK indexes are intentionally minimal (only the two CASCADE/SET NULL paths). The `RESTRICT` columns are not indexed because the app uses soft delete on profiles — hard deletes never happen, so the cascade-side scan never fires. Same trade-off as #19.

## Screenshots

N/A