### PR TITLE
fix: show theme toggle on public share page

### DIFF
--- a/app/components/AppHeader.vue
+++ b/app/components/AppHeader.vue
@@ -31,39 +31,41 @@ const themePreferenceLabel = computed(() => {
   return t('nav.themeSystem')
 })
 
+const themeMenuItems = computed(() => [
+  {
+    type: 'checkbox' as const,
+    label: t('nav.themeLight'),
+    icon: 'i-lucide-sun',
+    checked: colorMode.preference === 'light',
+    onSelect: () => {
+      colorMode.preference = 'light'
+    }
+  },
+  {
+    type: 'checkbox' as const,
+    label: t('nav.themeDark'),
+    icon: 'i-lucide-moon',
+    checked: colorMode.preference === 'dark',
+    onSelect: () => {
+      colorMode.preference = 'dark'
+    }
+  },
+  {
+    type: 'checkbox' as const,
+    label: t('nav.themeSystem'),
+    icon: 'i-lucide-monitor',
+    checked: colorMode.preference === 'system',
+    onSelect: () => {
+      colorMode.preference = 'system'
+    }
+  }
+])
+
 const items = computed(() => [
   {
     label: `${t('nav.theme')} (${themePreferenceLabel.value})`,
     icon: 'i-lucide-palette',
-    children: [
-      {
-        type: 'checkbox' as const,
-        label: t('nav.themeLight'),
-        icon: 'i-lucide-sun',
-        checked: colorMode.preference === 'light',
-        onSelect: () => {
-          colorMode.preference = 'light'
-        }
-      },
-      {
-        type: 'checkbox' as const,
-        label: t('nav.themeDark'),
-        icon: 'i-lucide-moon',
-        checked: colorMode.preference === 'dark',
-        onSelect: () => {
-          colorMode.preference = 'dark'
-        }
-      },
-      {
-        type: 'checkbox' as const,
-        label: t('nav.themeSystem'),
-        icon: 'i-lucide-monitor',
-        checked: colorMode.preference === 'system',
-        onSelect: () => {
-          colorMode.preference = 'system'
-        }
-      }
-    ]
+    children: themeMenuItems.value
   },
   {
     type: 'separator' as const
@@ -127,6 +129,17 @@ const items = computed(() => [
             :alt="user.user_metadata?.full_name"
             size="sm"
             class="cursor-pointer"
+          />
+        </UDropdownMenu>
+        <UDropdownMenu
+          v-else
+          :items="themeMenuItems"
+        >
+          <UButton
+            icon="i-lucide-palette"
+            color="neutral"
+            variant="ghost"
+            :aria-label="`${t('nav.theme')} (${themePreferenceLabel})`"
           />
         </UDropdownMenu>
       </template>


### PR DESCRIPTION
## Summary

- The theme toggle lived only inside the avatar dropdown menu, which renders just for logged-in users (`v-if="user"`). On the public share page (`header-only` layout, no session), the avatar—and therefore the theme switch—disappeared entirely.
- Extracted the three theme options into a reusable `themeMenuItems` computed.
- Added a standalone palette-icon dropdown for logged-out visitors so theme switching works on share pages; the authenticated avatar menu is unchanged.

## Type of Change

- [x] fix: bug fix

## Related Issues

<!-- none -->

## Test Plan

- [x] Tested locally
- [x] Lint passes (`pnpm lint`)
- [x] Typecheck passes (`pnpm typecheck`)

Open a share link (`/share/issues/<token>`) while logged out: a palette button appears top-right with Light / Dark / System options that switch the theme immediately. Logged-in users still see the avatar menu with theme options inside.

## Screenshots

<!-- not captured -->