### PR TITLE
fix: declutter issue share section with actions menu

### DIFF
--- a/app/pages/projects/[id]/issues/[issueId]/index.vue
+++ b/app/pages/projects/[id]/issues/[issueId]/index.vue
@@ -135,6 +135,21 @@ function openShareModal(action: 'enable' | 'regenerate' | 'disable') {
   showShareModal.value = true
 }
 
+const shareMenuItems = computed(() => [
+  {
+    label: t('issues.publicShare.regenerate'),
+    icon: 'i-lucide-refresh-cw',
+    onSelect: () => openShareModal('regenerate')
+  },
+  { type: 'separator' as const },
+  {
+    label: t('issues.publicShare.disable'),
+    icon: 'i-lucide-link-2-off',
+    color: 'error' as const,
+    onSelect: () => openShareModal('disable')
+  }
+])
+
 function copyShareLink() {
   if (!publicShare.value.shareUrl) return
   copyToClipboard(publicShare.value.shareUrl, { description: t('issues.publicShare.linkCopied') })
@@ -448,20 +463,34 @@ async function updateIssueStatus(nextStatus: IssueStatus) {
                 v-if="isApiBug"
                 class="space-y-3 border-t border-slate-200/70 pt-5 dark:border-slate-800/70"
               >
-                <div class="flex items-center justify-between gap-3">
+                <div class="flex items-center justify-between gap-2">
                   <span class="text-xs tracking-wider text-slate-500 uppercase dark:text-slate-400">
                     {{ $t('issues.publicShare.title') }}
                   </span>
-                  <UBadge
-                    :color="publicShare.enabled ? 'success' : 'neutral'"
-                    variant="subtle"
-                  >
-                    {{
-                      publicShare.enabled
-                        ? $t('issues.publicShare.enabledStatus')
-                        : $t('issues.publicShare.disabledStatus')
-                    }}
-                  </UBadge>
+                  <div class="flex items-center gap-1.5">
+                    <UBadge
+                      :color="publicShare.enabled ? 'success' : 'neutral'"
+                      variant="subtle"
+                    >
+                      {{
+                        publicShare.enabled
+                          ? $t('issues.publicShare.enabledStatus')
+                          : $t('issues.publicShare.disabledStatus')
+                      }}
+                    </UBadge>
+                    <UDropdownMenu
+                      v-if="publicShare.enabled && publicShare.shareUrl"
+                      :items="shareMenuItems"
+                    >
+                      <UButton
+                        size="xs"
+                        variant="ghost"
+                        color="neutral"
+                        icon="i-lucide-ellipsis-vertical"
+                        :aria-label="$t('issues.publicShare.manage')"
+                      />
+                    </UDropdownMenu>
+                  </div>
                 </div>
 
                 <template v-if="publicShare.enabled && publicShare.shareUrl">
@@ -469,6 +498,7 @@ async function updateIssueStatus(nextStatus: IssueStatus) {
                     :model-value="publicShare.shareUrl"
                     readonly
                     size="sm"
+                    class="w-full"
                   >
                     <template #trailing>
                       <UButton
@@ -481,26 +511,6 @@ async function updateIssueStatus(nextStatus: IssueStatus) {
                       />
                     </template>
                   </UInput>
-                  <div class="grid grid-cols-2 gap-2">
-                    <UButton
-                      color="neutral"
-                      variant="outline"
-                      icon="i-lucide-refresh-cw"
-                      block
-                      @click="openShareModal('regenerate')"
-                    >
-                      {{ $t('issues.publicShare.regenerate') }}
-                    </UButton>
-                    <UButton
-                      color="error"
-                      variant="outline"
-                      icon="i-lucide-link-2-off"
-                      block
-                      @click="openShareModal('disable')"
-                    >
-                      {{ $t('issues.publicShare.disable') }}
-                    </UButton>
-                  </div>
                 </template>
 
                 <UButton

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -259,6 +259,7 @@
       "disabled": "Public sharing disabled",
       "regenerate": "Regenerate Link",
       "disable": "Disable Sharing",
+      "manage": "Manage sharing",
       "enabledStatus": "Enabled",
       "disabledStatus": "Disabled",
       "enableConfirm": "Anyone with the share link can view this API Bug. Sensitive request headers are masked, but request and response bodies are shown as-is.",

--- a/i18n/locales/zh-TW.json
+++ b/i18n/locales/zh-TW.json
@@ -259,6 +259,7 @@
       "disabled": "Public Sharing 已關閉",
       "regenerate": "重新產生連結",
       "disable": "關閉分享",
+      "manage": "管理分享",
       "enabledStatus": "已開啟",
       "disabledStatus": "已關閉",
       "enableConfirm": "知道 Share Link 的任何人都能檢視此 API Bug。敏感 Request Headers 會被遮罩，但 Request Body 與 Response Body 會原樣顯示。",


### PR DESCRIPTION
## Summary

- Collapse the regenerate/disable share actions into a single ⋮ dropdown menu so the issue sidebar no longer shows every action button at once
- Make the share URL input full-width to align with the action buttons below it

## Type of Change

- [ ] feat: new feature
- [x] fix: bug fix
- [ ] refactor: code restructuring (no behavior change)
- [ ] chore: maintenance, CI, deps
- [ ] docs: documentation only

## Related Issues

## Test Plan

- [x] Tested locally
- [x] Lint passes (`pnpm lint`)
- [x] Typecheck passes (`pnpm typecheck`)

## Screenshots

| Before | After |
| --- | --- |
| Regenerate + Disable shown as a two-button grid | Both collapsed into a ⋮ menu next to the status badge; URL input full-width |